### PR TITLE
feat: config management commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "ink": "^5.2.0",
     "ink-ui": "^0.4.0",
     "pastel": "^3.0.0",
-    "react": "^18.3.1"
+    "react": "^18.3.1",
+    "zod": "^3.25.76"
   },
   "devDependencies": {
     "@sindresorhus/tsconfig": "^7.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       react:
         specifier: ^18.3.1
         version: 18.3.1
+      zod:
+        specifier: ^3.25.76
+        version: 3.25.76
     devDependencies:
       '@sindresorhus/tsconfig':
         specifier: ^7.0.0

--- a/src/commands/config/list.tsx
+++ b/src/commands/config/list.tsx
@@ -1,0 +1,46 @@
+import {Text, Box} from 'ink';
+import {useEffect} from 'react';
+import {z} from 'zod';
+import {readConfig, maskApiKey} from '../../lib/config.js';
+import {DEFAULT_API_URL} from '../../types/config.js';
+
+export const options = z.object({
+	json: z.boolean().default(false).describe('Output as JSON'),
+});
+
+type Props = {
+	options: z.infer<typeof options>;
+};
+
+export default function ConfigList({options}: Props) {
+	const config = readConfig();
+
+	const display = {
+		apiKey: config.apiKey ? maskApiKey(config.apiKey) : '(not set)',
+		apiUrl: config.apiUrl ?? DEFAULT_API_URL,
+	};
+
+	useEffect(() => {
+		if (options.json) {
+			console.log(JSON.stringify(display));
+			process.exit(0);
+		}
+	}, []);
+
+	if (options.json) {
+		return null;
+	}
+
+	return (
+		<Box flexDirection="column">
+			<Text>
+				<Text bold>API Key:  </Text>
+				<Text>{display.apiKey}</Text>
+			</Text>
+			<Text>
+				<Text bold>API URL:  </Text>
+				<Text>{display.apiUrl}</Text>
+			</Text>
+		</Box>
+	);
+}

--- a/src/commands/config/reset.tsx
+++ b/src/commands/config/reset.tsx
@@ -1,0 +1,29 @@
+import {Text} from 'ink';
+import {useEffect} from 'react';
+import {z} from 'zod';
+import {deleteConfig} from '../../lib/config.js';
+
+export const options = z.object({
+	json: z.boolean().default(false).describe('Output as JSON'),
+});
+
+type Props = {
+	options: z.infer<typeof options>;
+};
+
+export default function ConfigReset({options}: Props) {
+	useEffect(() => {
+		deleteConfig();
+
+		if (options.json) {
+			console.log(JSON.stringify({reset: true}));
+			process.exit(0);
+		}
+	}, []);
+
+	if (options.json) {
+		return null;
+	}
+
+	return <Text color="green">Config reset successfully</Text>;
+}

--- a/src/commands/config/set.tsx
+++ b/src/commands/config/set.tsx
@@ -1,0 +1,61 @@
+import {Text} from 'ink';
+import {useState, useEffect} from 'react';
+import {z} from 'zod';
+import {readConfig, writeConfig, maskApiKey} from '../../lib/config.js';
+import type {Config} from '../../types/config.js';
+
+const VALID_KEYS: Record<string, keyof Config> = {
+	'api-key': 'apiKey',
+	'api-url': 'apiUrl',
+};
+
+export const args = z.tuple([z.string().describe('key'), z.string().describe('value')]);
+export const options = z.object({
+	json: z.boolean().default(false).describe('Output as JSON'),
+});
+
+type Props = {
+	args: z.infer<typeof args>;
+	options: z.infer<typeof options>;
+};
+
+export default function ConfigSet({args: [key, value], options}: Props) {
+	const configKey = VALID_KEYS[key];
+	const [result, setResult] = useState<{success: boolean; display?: string} | null>(null);
+
+	useEffect(() => {
+		if (!configKey) {
+			const msg = `Invalid key: ${key}. Valid keys: ${Object.keys(VALID_KEYS).join(', ')}`;
+			if (options.json) {
+				console.log(JSON.stringify({error: true, code: 'INVALID_INPUT', message: msg}));
+				process.exit(1);
+			}
+
+			setResult({success: false});
+			return;
+		}
+
+		const config = readConfig();
+		config[configKey] = value;
+		writeConfig(config);
+
+		const display = configKey === 'apiKey' ? maskApiKey(value) : value;
+
+		if (options.json) {
+			console.log(JSON.stringify({key, value: display}));
+			process.exit(0);
+		}
+
+		setResult({success: true, display});
+	}, []);
+
+	if (!result) {
+		return null;
+	}
+
+	if (!result.success) {
+		return <Text color="red">Invalid key: {key}. Valid keys: {Object.keys(VALID_KEYS).join(', ')}</Text>;
+	}
+
+	return <Text color="green">Set {key} = {result.display}</Text>;
+}

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,0 +1,43 @@
+import {readFileSync, writeFileSync, mkdirSync, unlinkSync, existsSync} from 'node:fs';
+import {join} from 'node:path';
+import {homedir} from 'node:os';
+import type {Config} from '../types/config.js';
+
+export function getConfigDir(): string {
+	return process.env['TIMBERLOGS_CONFIG_DIR'] ?? join(homedir(), '.config', 'timberlogs');
+}
+
+export function getConfigPath(): string {
+	return join(getConfigDir(), 'config.json');
+}
+
+export function readConfig(): Config {
+	const path = getConfigPath();
+	try {
+		const data = readFileSync(path, 'utf-8');
+		return JSON.parse(data) as Config;
+	} catch {
+		return {};
+	}
+}
+
+export function writeConfig(config: Config): void {
+	const dir = getConfigDir();
+	mkdirSync(dir, {recursive: true, mode: 0o700});
+	writeFileSync(getConfigPath(), JSON.stringify(config, null, 2) + '\n', {mode: 0o600});
+}
+
+export function deleteConfig(): void {
+	const path = getConfigPath();
+	if (existsSync(path)) {
+		unlinkSync(path);
+	}
+}
+
+export function maskApiKey(key: string): string {
+	if (key.length < 16) {
+		return '****';
+	}
+
+	return key.slice(0, 8) + '****...' + key.slice(-4);
+}

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,0 +1,6 @@
+export interface Config {
+	apiKey?: string;
+	apiUrl?: string;
+}
+
+export const DEFAULT_API_URL = 'https://timberlogs-ingest.enaboapps.workers.dev';

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -10,12 +10,17 @@ export default defineConfig([
 		clean: true,
 	},
 	{
-		entry: {
-			'commands/index': 'src/commands/index.tsx',
-		},
+		entry: [
+			'src/commands/**/*.tsx',
+			'src/commands/**/*.ts',
+			'src/lib/**/*.ts',
+			'src/types/**/*.ts',
+			'src/components/**/*.tsx',
+		],
 		format: 'esm',
 		target: 'node20',
 		outDir: 'dist',
+		bundle: false,
 		clean: false,
 	},
 ]);


### PR DESCRIPTION
## Summary
- Add `config set`, `config list`, and `config reset` commands
- Config stored at `~/.config/timberlogs/config.json` with secure permissions (0600)
- Supports `api-key` and `api-url` settings
- `--json` flag for machine-readable output
- Uses useEffect pattern to avoid React render warnings with process.exit
- Added zod@3 dependency (v4 incompatible with Pastel)
- Updated tsup config for unbundled command file output

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `config list` command to view all configuration values with optional JSON output format
  * Added `config reset` command to restore your configuration to default settings
  * Added `config set` command to update individual configuration values from the command line
  * Configuration settings are now persistently stored and fully manageable through dedicated CLI commands

<!-- end of auto-generated comment: release notes by coderabbit.ai -->