### PR TITLE
feat: API client and time parser

### DIFF
--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,95 @@
+import {CliError, ErrorCode} from './errors.js';
+
+export interface ApiClient {
+	get<T>(path: string, params?: Record<string, string | number | undefined>): Promise<T>;
+	post<T>(path: string, body: unknown): Promise<T>;
+}
+
+export function createApiClient(options: {
+	apiKey: string;
+	baseUrl: string;
+	verbose?: boolean;
+}): ApiClient {
+	const {apiKey, baseUrl, verbose} = options;
+
+	const headers: Record<string, string> = {
+		Authorization: `Bearer ${apiKey}`,
+		'Content-Type': 'application/json',
+	};
+
+	async function request<T>(method: string, path: string, body?: unknown): Promise<T> {
+		const url = new URL(path, baseUrl);
+
+		const start = Date.now();
+		let response: Response;
+
+		try {
+			response = await fetch(url, {
+				method,
+				headers,
+				body: body !== undefined ? JSON.stringify(body) : undefined,
+			});
+		} catch (error) {
+			if (error instanceof TypeError) {
+				throw new CliError(ErrorCode.NETWORK_ERROR, `Network error: ${error.message}`);
+			}
+
+			throw error;
+		}
+
+		const elapsed = Date.now() - start;
+
+		if (verbose) {
+			console.error(`→ ${method} ${path} (${elapsed}ms) ${response.status}`);
+		}
+
+		if (!response.ok) {
+			let message: string;
+			try {
+				const body = (await response.json()) as {error?: string; message?: string};
+				message = body.message ?? body.error ?? response.statusText;
+			} catch {
+				message = response.statusText;
+			}
+
+			if (response.status === 401 || response.status === 403) {
+				throw new CliError(ErrorCode.AUTH_INVALID, `Authentication failed: ${message}`);
+			}
+
+			if (response.status === 404) {
+				throw new CliError(ErrorCode.NOT_FOUND, `Not found: ${message}`);
+			}
+
+			if (response.status === 429) {
+				throw new CliError(ErrorCode.RATE_LIMITED, `Rate limited: ${message}`);
+			}
+
+			if (response.status >= 500) {
+				throw new CliError(ErrorCode.NETWORK_ERROR, `Server error (${response.status}): ${message}`);
+			}
+
+			throw new CliError(ErrorCode.NETWORK_ERROR, `HTTP ${response.status}: ${message}`);
+		}
+
+		return (await response.json()) as T;
+	}
+
+	return {
+		get<T>(path: string, params?: Record<string, string | number | undefined>): Promise<T> {
+			const url = new URL(path, baseUrl);
+			if (params) {
+				for (const [key, value] of Object.entries(params)) {
+					if (value !== undefined) {
+						url.searchParams.set(key, String(value));
+					}
+				}
+			}
+
+			return request<T>('GET', `${url.pathname}${url.search}`);
+		},
+
+		post<T>(path: string, body: unknown): Promise<T> {
+			return request<T>('POST', path, body);
+		},
+	};
+}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,0 +1,54 @@
+import {readConfig} from './config.js';
+import {CliError, ErrorCode} from './errors.js';
+import {DEFAULT_API_URL} from '../types/config.js';
+
+const MULTIPLIERS: Record<string, number> = {
+	m: 60 * 1000,
+	h: 60 * 60 * 1000,
+	d: 24 * 60 * 60 * 1000,
+	w: 7 * 24 * 60 * 60 * 1000,
+};
+
+const RELATIVE_PATTERN = /^(\d+)(m|h|d|w)$/;
+
+export function parseRelativeTime(input: string): number {
+	const match = RELATIVE_PATTERN.exec(input);
+	if (match) {
+		const value = Number(match[1]);
+		const unit = match[2]!;
+		return Date.now() - value * MULTIPLIERS[unit]!;
+	}
+
+	const date = new Date(input);
+	if (!Number.isNaN(date.getTime())) {
+		return date.getTime();
+	}
+
+	const numeric = Number(input);
+	if (!Number.isNaN(numeric)) {
+		return numeric;
+	}
+
+	throw new CliError(
+		ErrorCode.INVALID_INPUT,
+		`Invalid time format: ${input}. Use 30m, 1h, 24h, 7d, or ISO 8601.`,
+	);
+}
+
+export function resolveApiUrl(flags: {apiUrl?: string}): string {
+	if (flags.apiUrl) {
+		return flags.apiUrl;
+	}
+
+	const envUrl = process.env['TIMBER_API_URL'];
+	if (envUrl) {
+		return envUrl;
+	}
+
+	const config = readConfig();
+	if (config.apiUrl) {
+		return config.apiUrl;
+	}
+
+	return DEFAULT_API_URL;
+}


### PR DESCRIPTION
## Summary
- Add `createApiClient()` with `get()` and `post()` methods
- Maps HTTP errors to typed `CliError` codes (401→AUTH_INVALID, 429→RATE_LIMITED, etc.)
- Verbose mode logs requests to stderr
- Add `parseRelativeTime()` supporting relative (30m, 1h, 7d) and ISO 8601 formats
- Add `resolveApiUrl()` with flag > env > config > default precedence

Closes #7