### PR TITLE
feat: login, logout, whoami commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "ink": "^5.2.0",
+    "ink-text-input": "^6.0.0",
     "ink-ui": "^0.4.0",
     "pastel": "^3.0.0",
     "react": "^18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       ink:
         specifier: ^5.2.0
         version: 5.2.1(@types/react@18.3.28)(react@18.3.1)
+      ink-text-input:
+        specifier: ^6.0.0
+        version: 6.0.0(ink@5.2.1(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
       ink-ui:
         specifier: ^0.4.0
         version: 0.4.0
@@ -527,6 +530,13 @@ packages:
   index-to-position@1.2.0:
     resolution: {integrity: sha512-Yg7+ztRkqslMAS2iFaU+Oa4KTSidr63OsFGlOrJoW981kIYO3CGCS3wA95P1mUi/IVSJkn0D479KTJpVpvFNuw==}
     engines: {node: '>=18'}
+
+  ink-text-input@6.0.0:
+    resolution: {integrity: sha512-Fw64n7Yha5deb1rHY137zHTAbSTNelUKuB5Kkk2HACXEtwIHBCf9OH2tP/LQ9fRYTl1F0dZgbW0zPnZk6FA9Lw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      ink: '>=5'
+      react: '>=18'
 
   ink-ui@0.4.0:
     resolution: {integrity: sha512-n9Zif1V/c3foSVCmbbU2/HUXwJFZpZUQlX1fowx1FQ8gCsHKXtokeHr+W4+oLnRoPK2ykT7m1D2UVPBKu8IgYg==}
@@ -1183,6 +1193,13 @@ snapshots:
   indent-string@5.0.0: {}
 
   index-to-position@1.2.0: {}
+
+  ink-text-input@6.0.0(ink@5.2.1(@types/react@18.3.28)(react@18.3.1))(react@18.3.1):
+    dependencies:
+      chalk: 5.6.2
+      ink: 5.2.1(@types/react@18.3.28)(react@18.3.1)
+      react: 18.3.1
+      type-fest: 4.41.0
 
   ink-ui@0.4.0: {}
 

--- a/src/commands/login.tsx
+++ b/src/commands/login.tsx
@@ -1,0 +1,100 @@
+import {Text, Box} from 'ink';
+import TextInput from 'ink-text-input';
+import {useState, useEffect} from 'react';
+import {z} from 'zod';
+import {readConfig, writeConfig} from '../lib/config.js';
+import {maskApiKey} from '../lib/auth.js';
+import {createApiClient} from '../lib/api.js';
+import {resolveApiUrl} from '../lib/time.js';
+import {handleError} from '../lib/errors.js';
+
+export const options = z.object({
+	'api-key': z.string().optional().describe('API key to store'),
+	json: z.boolean().default(false).describe('Output as JSON'),
+});
+
+type Props = {
+	options: z.infer<typeof options>;
+};
+
+export default function Login({options}: Props) {
+	const [inputValue, setInputValue] = useState('');
+	const [status, setStatus] = useState<'input' | 'validating' | 'success' | 'error'>('input');
+	const [errorMsg, setErrorMsg] = useState('');
+
+	const apiKeyFromFlag = options['api-key'];
+
+	useEffect(() => {
+		if (apiKeyFromFlag) {
+			void validateAndStore(apiKeyFromFlag);
+		}
+	}, []);
+
+	async function validateAndStore(key: string) {
+		setStatus('validating');
+
+		const baseUrl = resolveApiUrl({});
+		const client = createApiClient({apiKey: key, baseUrl});
+
+		try {
+			await client.get('/v1/logs', {limit: 1});
+		} catch (error) {
+			if (options.json) {
+				handleError(error, true);
+			}
+
+			setStatus('error');
+			setErrorMsg(error instanceof Error ? error.message : String(error));
+			return;
+		}
+
+		const config = readConfig();
+		config.apiKey = key;
+		writeConfig(config);
+
+		if (options.json) {
+			console.log(JSON.stringify({authenticated: true, keyPrefix: maskApiKey(key)}));
+			process.exit(0);
+		}
+
+		setStatus('success');
+	}
+
+	function handleSubmit(value: string) {
+		const trimmed = value.trim();
+		if (trimmed) {
+			void validateAndStore(trimmed);
+		}
+	}
+
+	if (apiKeyFromFlag && status === 'input') {
+		return null;
+	}
+
+	if (status === 'validating') {
+		return <Text color="yellow">Validating API key...</Text>;
+	}
+
+	if (status === 'error') {
+		return <Text color="red">✗ {errorMsg}</Text>;
+	}
+
+	if (status === 'success') {
+		return (
+			<Box flexDirection="column">
+				<Text color="green">✓ Authenticated successfully</Text>
+				<Text color="green">✓ API key saved to ~/.config/timberlogs/config.json</Text>
+			</Box>
+		);
+	}
+
+	return (
+		<Box flexDirection="column">
+			<Text>Paste your API key (from app.timberlogs.dev {'>'} Settings {'>'} API Keys):</Text>
+			<Box>
+				<Text>{'> '}</Text>
+				<TextInput value={inputValue} onChange={setInputValue} onSubmit={handleSubmit} mask="*" />
+			</Box>
+		</Box>
+	);
+}

--- a/src/commands/logout.tsx
+++ b/src/commands/logout.tsx
@@ -1,0 +1,39 @@
+import {Text} from 'ink';
+import {useEffect} from 'react';
+import {z} from 'zod';
+import {readConfig, writeConfig} from '../lib/config.js';
+
+export const options = z.object({
+	json: z.boolean().default(false).describe('Output as JSON'),
+});
+
+type Props = {
+	options: z.infer<typeof options>;
+};
+
+export default function Logout({options}: Props) {
+	const config = readConfig();
+	const hadKey = Boolean(config.apiKey);
+
+	useEffect(() => {
+		if (hadKey) {
+			delete config.apiKey;
+			writeConfig(config);
+		}
+
+		if (options.json) {
+			console.log(JSON.stringify({loggedOut: true}));
+			process.exit(0);
+		}
+	}, []);
+
+	if (options.json) {
+		return null;
+	}
+
+	if (!hadKey) {
+		return <Text color="yellow">No API key configured</Text>;
+	}
+
+	return <Text color="green">✓ Logged out — API key removed</Text>;
+}

--- a/src/commands/whoami.tsx
+++ b/src/commands/whoami.tsx
@@ -1,0 +1,98 @@
+import {Text, Box} from 'ink';
+import {useState, useEffect} from 'react';
+import {z} from 'zod';
+import {resolveApiKey, maskApiKey} from '../lib/auth.js';
+import {createApiClient} from '../lib/api.js';
+import {resolveApiUrl} from '../lib/time.js';
+import {handleError, CliError, ErrorCode} from '../lib/errors.js';
+
+export const options = z.object({
+	'api-key': z.string().optional().describe('Override API key'),
+	json: z.boolean().default(false).describe('Output as JSON'),
+});
+
+type Props = {
+	options: z.infer<typeof options>;
+};
+
+type Result = {
+	authenticated: boolean;
+	keyPrefix?: string;
+	apiUrl?: string;
+	error?: string;
+};
+
+export default function WhoAmI({options}: Props) {
+	const [result, setResult] = useState<Result | null>(null);
+
+	useEffect(() => {
+		void check();
+	}, []);
+
+	async function check() {
+		const key = resolveApiKey({'apiKey': options['api-key']});
+		if (!key) {
+			if (options.json) {
+				handleError(new CliError(ErrorCode.AUTH_REQUIRED, 'Not authenticated'), true);
+			}
+
+			setResult({authenticated: false, error: 'Not authenticated. Run `timberlogs login` to get started.'});
+			return;
+		}
+
+		const apiUrl = resolveApiUrl({});
+		const client = createApiClient({apiKey: key, baseUrl: apiUrl});
+
+		try {
+			await client.get('/v1/logs', {limit: 1});
+		} catch (error) {
+			if (options.json) {
+				handleError(error, true);
+			}
+
+			setResult({
+				authenticated: false,
+				error: 'API key is invalid or revoked',
+			});
+			return;
+		}
+
+		const info = {
+			authenticated: true,
+			keyPrefix: maskApiKey(key),
+			apiUrl,
+		};
+
+		if (options.json) {
+			console.log(JSON.stringify(info));
+			process.exit(0);
+		}
+
+		setResult(info);
+	}
+
+	if (!result) {
+		return <Text color="yellow">Checking authentication...</Text>;
+	}
+
+	if (!result.authenticated) {
+		return <Text color="red">✗ {result.error}</Text>;
+	}
+
+	return (
+		<Box flexDirection="column">
+			<Text>
+				<Text bold>{'Status:       '}</Text>
+				<Text color="green">Authenticated</Text>
+			</Text>
+			<Text>
+				<Text bold>{'API Key:      '}</Text>
+				<Text>{result.keyPrefix}</Text>
+			</Text>
+			<Text>
+				<Text bold>{'API Endpoint: '}</Text>
+				<Text>{result.apiUrl}</Text>
+			</Text>
+		</Box>
+	);
+}


### PR DESCRIPTION
## Summary
- Add `timberlogs login` with API key validation, masked interactive input, and `--api-key` flag
- Add `timberlogs logout` to remove stored API key
- Add `timberlogs whoami` to show auth status and verify key validity
- All commands support `--json` for machine-readable output

Closes #9