### PR TITLE
feat: logs command with query and search

### DIFF
--- a/src/commands/logs.tsx
+++ b/src/commands/logs.tsx
@@ -1,0 +1,106 @@
+import {Text} from 'ink';
+import {useState, useEffect} from 'react';
+import {z} from 'zod';
+import {requireApiKey} from '../lib/auth.js';
+import {createApiClient} from '../lib/api.js';
+import {resolveApiUrl, parseRelativeTime} from '../lib/time.js';
+import {handleError} from '../lib/errors.js';
+import {isJsonMode, jsonOutput} from '../lib/output.js';
+import type {LogsResponse} from '../types/log.js';
+import LogTable from '../components/LogTable.js';
+
+export const options = z.object({
+	level: z.string().optional().describe('Filter by level (debug|info|warn|error)'),
+	source: z.string().optional().describe('Filter by source'),
+	env: z.string().optional().describe('Filter by environment'),
+	search: z.string().optional().describe('Full-text search query'),
+	from: z.string().default('1h').describe('Start time (e.g., 30m, 1h, 24h, 7d, ISO 8601)'),
+	to: z.string().optional().describe('End time'),
+	limit: z.number().default(50).describe('Max logs to return'),
+	'user-id': z.string().optional().describe('Filter by user ID'),
+	'session-id': z.string().optional().describe('Filter by session ID'),
+	'flow-id': z.string().optional().describe('Filter by flow ID'),
+	dataset: z.string().optional().describe('Filter by dataset'),
+	json: z.boolean().default(false).describe('Output as JSON'),
+	'api-key': z.string().optional().describe('Override API key'),
+	'api-url': z.string().optional().describe('Override API URL'),
+	verbose: z.boolean().default(false).describe('Show debug info'),
+});
+
+type Props = {
+	options: z.infer<typeof options>;
+};
+
+export default function Logs({options: flags}: Props) {
+	const [data, setData] = useState<LogsResponse | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const json = isJsonMode(flags);
+
+	useEffect(() => {
+		void fetchLogs();
+	}, []);
+
+	async function fetchLogs() {
+		try {
+			const apiKey = requireApiKey({apiKey: flags['api-key']});
+			const baseUrl = resolveApiUrl({apiUrl: flags['api-url']});
+			const client = createApiClient({apiKey, baseUrl, verbose: flags.verbose});
+
+			const from = parseRelativeTime(flags.from);
+			const to = flags.to ? parseRelativeTime(flags.to) : undefined;
+
+			const params: Record<string, string | number | undefined> = {
+				level: flags.level,
+				source: flags.source,
+				environment: flags.env,
+				from,
+				to,
+				limit: flags.limit,
+				userId: flags['user-id'],
+				sessionId: flags['session-id'],
+				flowId: flags['flow-id'],
+				dataset: flags.dataset,
+			};
+
+			let response: LogsResponse;
+
+			if (flags.search) {
+				response = await client.get<LogsResponse>('/v1/logs/search', {
+					q: flags.search,
+					...params,
+				});
+			} else {
+				response = await client.get<LogsResponse>('/v1/logs', params);
+			}
+
+			if (json) {
+				jsonOutput(response);
+			}
+
+			setData(response);
+		} catch (err) {
+			if (json) {
+				handleError(err, true);
+			}
+
+			setError(err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	if (error) {
+		return <Text color="red">✗ {error}</Text>;
+	}
+
+	if (!data) {
+		return <Text color="yellow">Fetching logs...</Text>;
+	}
+
+	const filters: string[] = [];
+	if (flags.level) filters.push(`level=${flags.level}`);
+	if (flags.source) filters.push(`source=${flags.source}`);
+	if (flags.env) filters.push(`env=${flags.env}`);
+	if (flags.search) filters.push(`search="${flags.search}"`);
+	const filterSummary = filters.length > 0 ? `(${filters.join(', ')})` : undefined;
+
+	return <LogTable logs={data.logs} pagination={data.pagination} filterSummary={filterSummary} />;
+}

--- a/src/components/LogDetail.tsx
+++ b/src/components/LogDetail.tsx
@@ -1,0 +1,65 @@
+import {Text, Box} from 'ink';
+import type {LogEntry} from '../types/log.js';
+
+type Props = {
+	log: LogEntry;
+};
+
+const LEVEL_COLORS: Record<string, string> = {
+	debug: 'gray',
+	info: 'blue',
+	warn: 'yellow',
+	error: 'red',
+};
+
+function Field({label, value}: {label: string; value: string | undefined}) {
+	if (!value) return null;
+	return (
+		<Text>
+			<Text bold dimColor>{label.padEnd(14)}</Text>
+			<Text>{value}</Text>
+		</Text>
+	);
+}
+
+export default function LogDetail({log}: Props) {
+	return (
+		<Box flexDirection="column" paddingX={1}>
+			<Box marginBottom={1}>
+				<Text bold inverse>{` ${log.level.toUpperCase()} `}</Text>
+				<Text> </Text>
+				<Text>{log.message}</Text>
+			</Box>
+
+			<Field label="Timestamp" value={log.timestamp} />
+			<Field label="Level" value={log.level} />
+			<Field label="Source" value={log.source} />
+			<Field label="Environment" value={log.environment} />
+			<Field label="Dataset" value={log.dataset} />
+			<Field label="Version" value={log.version} />
+			<Field label="User ID" value={log.userId} />
+			<Field label="Session ID" value={log.sessionId} />
+			<Field label="Request ID" value={log.requestId} />
+			<Field label="Flow" value={log.flowId && log.stepIndex !== undefined ? `${log.flowId} #${log.stepIndex}` : log.flowId} />
+			<Field label="Tags" value={log.tags?.join(', ')} />
+
+			{log.data && Object.keys(log.data).length > 0 && (
+				<Box flexDirection="column" marginTop={1}>
+					<Text bold>Data:</Text>
+					<Text>{JSON.stringify(log.data, null, 2)}</Text>
+				</Box>
+			)}
+
+			{(log.errorName || log.errorStack) && (
+				<Box flexDirection="column" marginTop={1}>
+					<Text bold color="red">{log.errorName ?? 'Error'}</Text>
+					{log.errorStack && <Text dimColor>{log.errorStack}</Text>}
+				</Box>
+			)}
+
+			<Box marginTop={1}>
+				<Text dimColor>Press Esc or Backspace to go back</Text>
+			</Box>
+		</Box>
+	);
+}

--- a/src/components/LogTable.tsx
+++ b/src/components/LogTable.tsx
@@ -1,0 +1,109 @@
+import {Text, Box, useInput} from 'ink';
+import {useState} from 'react';
+import type {LogEntry, LogsResponse} from '../types/log.js';
+import LogDetail from './LogDetail.js';
+
+type Props = {
+	logs: LogEntry[];
+	pagination: LogsResponse['pagination'];
+	filterSummary?: string;
+};
+
+const LEVEL_COLORS: Record<string, string> = {
+	debug: 'gray',
+	info: 'blue',
+	warn: 'yellow',
+	error: 'red',
+};
+
+function formatTime(timestamp: string): string {
+	const d = new Date(timestamp);
+	const h = String(d.getHours()).padStart(2, '0');
+	const m = String(d.getMinutes()).padStart(2, '0');
+	const s = String(d.getSeconds()).padStart(2, '0');
+	const ms = String(d.getMilliseconds()).padStart(3, '0');
+	return `${h}:${m}:${s}.${ms}`;
+}
+
+export default function LogTable({logs, pagination, filterSummary}: Props) {
+	const [cursor, setCursor] = useState(0);
+	const [expanded, setExpanded] = useState<number | null>(null);
+
+	const maxRows = Math.min(logs.length, (process.stdout.rows || 24) - 5);
+	const cols = process.stdout.columns || 80;
+
+	useInput((input, key) => {
+		if (expanded !== null) {
+			if (key.escape || key.backspace || key.delete) {
+				setExpanded(null);
+			}
+
+			return;
+		}
+
+		if (key.upArrow) {
+			setCursor(c => Math.max(0, c - 1));
+		} else if (key.downArrow) {
+			setCursor(c => Math.min(logs.length - 1, c + 1));
+		} else if (key.return) {
+			setExpanded(cursor);
+		} else if (input === 'q') {
+			process.exit(0);
+		}
+	});
+
+	if (expanded !== null && logs[expanded]) {
+		return <LogDetail log={logs[expanded]} />;
+	}
+
+	if (logs.length === 0) {
+		return <Text dimColor>No logs found{filterSummary ? ` ${filterSummary}` : ''}</Text>;
+	}
+
+	const scrollOffset = Math.max(0, cursor - maxRows + 1);
+	const visible = logs.slice(scrollOffset, scrollOffset + maxRows);
+
+	const levelW = 5;
+	const timeW = 12;
+	const sourceW = 16;
+	const msgW = Math.max(20, cols - levelW - timeW - sourceW - 6);
+
+	return (
+		<Box flexDirection="column">
+			<Text dimColor>
+				Showing {logs.length} logs{filterSummary ? ` ${filterSummary}` : ''}
+			</Text>
+
+			<Text bold dimColor>
+				{'LEVEL'.padEnd(levelW)} {'TIME'.padEnd(timeW)} {'SOURCE'.padEnd(sourceW)} MESSAGE
+			</Text>
+
+			{visible.map((log, i) => {
+				const idx = scrollOffset + i;
+				const isSelected = idx === cursor;
+				const level = log.level.padEnd(levelW);
+				const time = formatTime(log.timestamp).padEnd(timeW);
+				const source = (log.source ?? '').slice(0, sourceW).padEnd(sourceW);
+				const msg = log.message.slice(0, msgW);
+
+				return (
+					<Text key={log.id} inverse={isSelected}>
+						<Text color={LEVEL_COLORS[log.level]}>{level}</Text>
+						{' '}
+						<Text dimColor>{time}</Text>
+						{' '}
+						<Text>{source}</Text>
+						{' '}
+						<Text>{msg}</Text>
+					</Text>
+				);
+			})}
+
+			<Text dimColor>
+				{pagination.offset + logs.length}/{pagination.total} logs
+				{pagination.hasMore ? '' : ' (end)'}
+				{'  ↑↓ navigate  Enter expand  q quit'}
+			</Text>
+		</Box>
+	);
+}

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -1,0 +1,29 @@
+export interface LogEntry {
+	id: string;
+	level: 'debug' | 'info' | 'warn' | 'error';
+	message: string;
+	timestamp: string;
+	source?: string;
+	environment?: string;
+	dataset?: string;
+	version?: string;
+	userId?: string;
+	sessionId?: string;
+	requestId?: string;
+	flowId?: string;
+	stepIndex?: number;
+	tags?: string[];
+	data?: Record<string, unknown>;
+	errorName?: string;
+	errorStack?: string;
+}
+
+export interface LogsResponse {
+	logs: LogEntry[];
+	pagination: {
+		total: number;
+		offset: number;
+		limit: number;
+		hasMore: boolean;
+	};
+}


### PR DESCRIPTION
## Summary
- Add `timberlogs logs` command for querying logs via `/v1/logs`
- `--search` flag switches to `/v1/logs/search` for full-text search
- Full set of filter flags: `--level`, `--source`, `--env`, `--from`, `--to`, `--limit`, etc.
- Interactive `LogTable` component with keyboard navigation (↑↓, Enter to expand, q to quit)
- `LogDetail` component showing all log fields including data and error stack
- `--json` mode for machine-readable output

Closes #11