### PR TITLE
feat: flows show command with timeline

### DIFF
--- a/src/commands/flows/show.tsx
+++ b/src/commands/flows/show.tsx
@@ -1,0 +1,98 @@
+import {Text} from 'ink';
+import {useState, useEffect} from 'react';
+import {z} from 'zod';
+import {requireApiKey} from '../../lib/auth.js';
+import {createApiClient} from '../../lib/api.js';
+import {resolveApiUrl} from '../../lib/time.js';
+import {handleError} from '../../lib/errors.js';
+import {isJsonMode, jsonOutput} from '../../lib/output.js';
+import type {LogsResponse} from '../../types/log.js';
+import FlowTimeline from '../../components/FlowTimeline.js';
+
+export const args = z.tuple([z.string().describe('flowId')]);
+
+export const options = z.object({
+	json: z.boolean().default(false).describe('Output as JSON'),
+	'api-key': z.string().optional().describe('Override API key'),
+	'api-url': z.string().optional().describe('Override API URL'),
+	verbose: z.boolean().default(false).describe('Show debug info'),
+});
+
+type Props = {
+	args: z.infer<typeof args>;
+	options: z.infer<typeof options>;
+};
+
+type FlowData = {
+	flowId: string;
+	logs: LogsResponse['logs'];
+	stepCount: number;
+	durationMs: number;
+	hasErrors: boolean;
+};
+
+export default function FlowsShow({args: [flowId], options: flags}: Props) {
+	const [data, setData] = useState<FlowData | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const json = isJsonMode(flags);
+
+	useEffect(() => {
+		void fetchFlow();
+	}, []);
+
+	async function fetchFlow() {
+		try {
+			const apiKey = requireApiKey({apiKey: flags['api-key']});
+			const baseUrl = resolveApiUrl({apiUrl: flags['api-url']});
+			const client = createApiClient({apiKey, baseUrl, verbose: flags.verbose});
+
+			const response = await client.get<LogsResponse>('/v1/logs', {
+				flowId,
+				limit: 1000,
+			});
+
+			const logs = response.logs;
+			const stepCount = logs.length;
+			const durationMs = logs.length > 1
+				? new Date(logs[logs.length - 1]!.timestamp).getTime() - new Date(logs[0]!.timestamp).getTime()
+				: 0;
+			const hasErrors = logs.some(l => l.level === 'error');
+
+			const flowData: FlowData = {flowId, logs, stepCount, durationMs, hasErrors};
+
+			if (json) {
+				jsonOutput(flowData);
+			}
+
+			setData(flowData);
+		} catch (err) {
+			if (json) {
+				handleError(err, true);
+			}
+
+			setError(err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	if (error) {
+		return <Text color="red">✗ {error}</Text>;
+	}
+
+	if (!data) {
+		return <Text color="yellow">Fetching flow {flowId}...</Text>;
+	}
+
+	if (data.logs.length === 0) {
+		return <Text dimColor>No logs found for flow {flowId}</Text>;
+	}
+
+	return (
+		<FlowTimeline
+			flowId={data.flowId}
+			logs={data.logs}
+			stepCount={data.stepCount}
+			durationMs={data.durationMs}
+			hasErrors={data.hasErrors}
+		/>
+	);
+}

--- a/src/components/FlowTimeline.tsx
+++ b/src/components/FlowTimeline.tsx
@@ -1,0 +1,91 @@
+import {Text, Box, useInput} from 'ink';
+import type {LogEntry} from '../types/log.js';
+
+type Props = {
+	flowId: string;
+	logs: LogEntry[];
+	stepCount: number;
+	durationMs: number;
+	hasErrors: boolean;
+};
+
+const LEVEL_COLORS: Record<string, string> = {
+	debug: 'gray',
+	info: 'blue',
+	warn: 'yellow',
+	error: 'red',
+};
+
+function formatTime(timestamp: string): string {
+	const d = new Date(timestamp);
+	const h = String(d.getHours()).padStart(2, '0');
+	const m = String(d.getMinutes()).padStart(2, '0');
+	const s = String(d.getSeconds()).padStart(2, '0');
+	const ms = String(d.getMilliseconds()).padStart(3, '0');
+	return `${h}:${m}:${s}.${ms}`;
+}
+
+function formatDuration(ms: number): string {
+	if (ms < 1000) return `${ms}ms`;
+	return `${(ms / 1000).toFixed(3)}s`;
+}
+
+function formatDataInline(data: Record<string, unknown> | undefined, maxWidth: number): string {
+	if (!data) return '';
+	const entries = Object.entries(data).slice(0, 3);
+	const parts = entries.map(([k, v]) => {
+		const val = typeof v === 'string' ? v : JSON.stringify(v);
+		return `${k}=${val}`;
+	});
+	const result = parts.join(' ');
+	return result.length > maxWidth ? result.slice(0, maxWidth - 1) + '…' : result;
+}
+
+export default function FlowTimeline({flowId, logs, stepCount, durationMs, hasErrors}: Props) {
+	useInput((input) => {
+		if (input === 'q') {
+			process.exit(0);
+		}
+	});
+
+	const cols = process.stdout.columns || 80;
+	const stepW = String(logs.length).length + 1;
+	const errorCount = logs.filter(l => l.level === 'error').length;
+
+	return (
+		<Box flexDirection="column">
+			<Text bold>Flow: {flowId}</Text>
+			<Text dimColor>{'─'.repeat(Math.min(60, cols))}</Text>
+
+			{logs.map((log) => {
+				const step = `#${log.stepIndex ?? '?'}`.padStart(stepW + 1);
+				const time = formatTime(log.timestamp);
+				const level = log.level.padEnd(5);
+				const dataStr = formatDataInline(log.data, Math.max(10, cols - stepW - 14 - 6 - log.message.length - 4));
+
+				return (
+					<Text key={log.id}>
+						<Text dimColor>{step}</Text>
+						{'  '}
+						<Text dimColor>{time}</Text>
+						{'  '}
+						<Text color={LEVEL_COLORS[log.level]}>{level}</Text>
+						{'  '}
+						<Text>{log.message}</Text>
+						{dataStr ? <Text dimColor>  {dataStr}</Text> : null}
+					</Text>
+				);
+			})}
+
+			<Text dimColor>{'─'.repeat(Math.min(60, cols))}</Text>
+			<Text>
+				<Text bold>Steps: </Text><Text>{stepCount}</Text>
+				<Text>  |  </Text>
+				<Text bold>Duration: </Text><Text>{formatDuration(durationMs)}</Text>
+				<Text>  |  </Text>
+				<Text bold>Errors: </Text><Text color={hasErrors ? 'red' : 'green'}>{errorCount}</Text>
+			</Text>
+			<Text dimColor>q quit</Text>
+		</Box>
+	);
+}


### PR DESCRIPTION
## Summary
- Add `timberlogs flows show <flow-id>` to display all logs in a flow as a timeline
- Fetches logs via `GET /v1/logs?flowId={id}&limit=1000`
- Computes `stepCount`, `durationMs`, `hasErrors` from the response
- Interactive `FlowTimeline` component with step index, timestamp, level, message, and inline data
- `--json` mode outputs full flow data with computed fields

Closes #13