### PR TITLE
feat: stats command with volume and comparison

### DIFF
--- a/src/commands/stats.tsx
+++ b/src/commands/stats.tsx
@@ -1,0 +1,134 @@
+import {Text} from 'ink';
+import {useState, useEffect} from 'react';
+import {z} from 'zod';
+import {requireApiKey} from '../lib/auth.js';
+import {createApiClient} from '../lib/api.js';
+import {resolveApiUrl, parseRelativeTime} from '../lib/time.js';
+import {handleError} from '../lib/errors.js';
+import {isJsonMode, jsonOutput} from '../lib/output.js';
+import StatsView from '../components/StatsView.js';
+
+export const options = z.object({
+	from: z.string().default('24h').describe('Start time (e.g., 24h, 7d)'),
+	to: z.string().optional().describe('End time'),
+	'group-by': z.string().default('day').describe('Group by: hour, day, source'),
+	source: z.string().optional().describe('Filter by source'),
+	env: z.string().optional().describe('Filter by environment'),
+	dataset: z.string().optional().describe('Filter by dataset'),
+	json: z.boolean().default(false).describe('Output as JSON'),
+	'api-key': z.string().optional().describe('Override API key'),
+	'api-url': z.string().optional().describe('Override API URL'),
+	verbose: z.boolean().default(false).describe('Show debug info'),
+});
+
+type Props = {
+	options: z.infer<typeof options>;
+};
+
+type StatsData = {
+	stats: unknown[];
+	totals: {debug: number; info: number; warn: number; error: number; total: number};
+	period: {from: string; to: string; groupBy: string};
+	comparison?: {yesterdayTotal: number; changePercent: number; trend: 'up' | 'down' | 'stable'};
+	groupBySource?: Array<{source: string; total: number; debug: number; info: number; warn: number; error: number}>;
+};
+
+function toDateString(ms: number): string {
+	return new Date(ms).toISOString().slice(0, 10);
+}
+
+export default function Stats({options: flags}: Props) {
+	const [data, setData] = useState<StatsData | null>(null);
+	const [error, setError] = useState<string | null>(null);
+	const json = isJsonMode(flags);
+
+	useEffect(() => {
+		void fetchStats();
+	}, []);
+
+	async function fetchStats() {
+		try {
+			const apiKey = requireApiKey({apiKey: flags['api-key']});
+			const baseUrl = resolveApiUrl({apiUrl: flags['api-url']});
+			const client = createApiClient({apiKey, baseUrl, verbose: flags.verbose});
+
+			const fromMs = parseRelativeTime(flags.from);
+			const toMs = flags.to ? parseRelativeTime(flags.to) : Date.now();
+			const fromDate = toDateString(fromMs);
+			const toDate = toDateString(toMs);
+
+			const [statsResponse, summaryResponse] = await Promise.all([
+				client.get<{stats: unknown[]; totals?: Record<string, number>}>('/v1/stats', {
+					from: fromDate,
+					to: toDate,
+					groupBy: flags['group-by'],
+					source: flags.source,
+					environment: flags.env,
+					dataset: flags.dataset,
+				}),
+				client.get<{today?: number; yesterday?: number; totals?: Record<string, number>}>('/v1/stats/summary').catch(() => null),
+			]);
+
+			const totals = {
+				debug: (statsResponse.totals?.['debug'] as number) ?? 0,
+				info: (statsResponse.totals?.['info'] as number) ?? 0,
+				warn: (statsResponse.totals?.['warn'] as number) ?? 0,
+				error: (statsResponse.totals?.['error'] as number) ?? 0,
+				total: (statsResponse.totals?.['total'] as number) ?? 0,
+			};
+
+			let comparison: StatsData['comparison'];
+			if (summaryResponse?.today !== undefined && summaryResponse?.yesterday !== undefined) {
+				const yesterdayTotal = summaryResponse.yesterday;
+				const todayTotal = summaryResponse.today;
+				const changePercent = yesterdayTotal > 0
+					? ((todayTotal - yesterdayTotal) / yesterdayTotal) * 100
+					: 0;
+				const trend = changePercent > 1 ? 'up' as const : changePercent < -1 ? 'down' as const : 'stable' as const;
+				comparison = {yesterdayTotal, changePercent, trend};
+			}
+
+			let groupBySource: StatsData['groupBySource'];
+			if (flags['group-by'] === 'source' && Array.isArray(statsResponse.stats)) {
+				groupBySource = statsResponse.stats as StatsData['groupBySource'];
+			}
+
+			const result: StatsData = {
+				stats: statsResponse.stats,
+				totals,
+				period: {from: fromDate, to: toDate, groupBy: flags['group-by']},
+				comparison,
+				groupBySource,
+			};
+
+			if (json) {
+				jsonOutput(result);
+			}
+
+			setData(result);
+		} catch (err) {
+			if (json) {
+				handleError(err, true);
+			}
+
+			setError(err instanceof Error ? err.message : String(err));
+		}
+	}
+
+	if (error) {
+		return <Text color="red">✗ {error}</Text>;
+	}
+
+	if (!data) {
+		return <Text color="yellow">Fetching stats...</Text>;
+	}
+
+	return (
+		<StatsView
+			totals={data.totals}
+			period={flags.from}
+			comparison={data.comparison}
+			groupBySource={data.groupBySource}
+		/>
+	);
+}

--- a/src/components/StatsView.tsx
+++ b/src/components/StatsView.tsx
@@ -1,0 +1,132 @@
+import {Text, Box, useInput} from 'ink';
+
+type LevelStats = {
+	debug: number;
+	info: number;
+	warn: number;
+	error: number;
+	total: number;
+};
+
+type Props = {
+	totals: LevelStats;
+	period: string;
+	comparison?: {
+		yesterdayTotal: number;
+		changePercent: number;
+		trend: 'up' | 'down' | 'stable';
+	};
+	groupBySource?: Array<{
+		source: string;
+		total: number;
+		debug: number;
+		info: number;
+		warn: number;
+		error: number;
+	}>;
+};
+
+const LEVEL_COLORS: Record<string, string> = {
+	debug: 'gray',
+	info: 'blue',
+	warn: 'yellow',
+	error: 'red',
+};
+
+function formatNumber(n: number): string {
+	return n.toLocaleString();
+}
+
+function renderBar(value: number, total: number, maxWidth: number): string {
+	if (total === 0) return '';
+	const filled = Math.round((value / total) * maxWidth);
+	return '█'.repeat(filled) + '░'.repeat(maxWidth - filled);
+}
+
+export default function StatsView({totals, period, comparison, groupBySource}: Props) {
+	useInput((input) => {
+		if (input === 'q') {
+			process.exit(0);
+		}
+	});
+
+	const cols = process.stdout.columns || 80;
+	const barWidth = Math.min(21, Math.max(10, cols - 40));
+
+	const trendText = comparison
+		? comparison.trend === 'up'
+			? `+${comparison.changePercent.toFixed(1)}% ↑`
+			: comparison.trend === 'down'
+				? `-${Math.abs(comparison.changePercent).toFixed(1)}% ↓`
+				: 'stable'
+		: '';
+	const trendColor = comparison
+		? comparison.trend === 'up'
+			? 'green'
+			: comparison.trend === 'down'
+				? 'red'
+				: 'gray'
+		: 'gray';
+
+	if (groupBySource && groupBySource.length > 0) {
+		return (
+			<Box flexDirection="column">
+				<Text bold>Log Volume (last {period})</Text>
+				{comparison && (
+					<Text>
+						<Text bold>Total: {formatNumber(totals.total)}</Text>
+						{'  '}
+						<Text color={trendColor}>{trendText}</Text>
+					</Text>
+				)}
+				<Text> </Text>
+				<Text bold dimColor>
+					{'Source'.padEnd(16)} {'Total'.padStart(8)} {'Debug'.padStart(8)} {'Info'.padStart(8)} {'Warn'.padStart(8)} {'Error'.padStart(8)}
+				</Text>
+				{groupBySource.map((row) => (
+					<Text key={row.source}>
+						{row.source.slice(0, 16).padEnd(16)} {formatNumber(row.total).padStart(8)} {formatNumber(row.debug).padStart(8)} {formatNumber(row.info).padStart(8)} {formatNumber(row.warn).padStart(8)} {formatNumber(row.error).padStart(8)}
+					</Text>
+				))}
+				<Text dimColor>q quit</Text>
+			</Box>
+		);
+	}
+
+	const levels: Array<{name: string; value: number}> = [
+		{name: 'debug', value: totals.debug},
+		{name: 'info', value: totals.info},
+		{name: 'warn', value: totals.warn},
+		{name: 'error', value: totals.error},
+	];
+
+	return (
+		<Box flexDirection="column">
+			<Box>
+				<Text bold>Log Volume (last {period})</Text>
+				{comparison && (
+					<>
+						<Text>  </Text>
+						<Text color={trendColor}>{trendText}</Text>
+					</>
+				)}
+			</Box>
+			<Text bold>Total: {formatNumber(totals.total)}</Text>
+			<Text> </Text>
+			{levels.map(({name, value}) => {
+				const pct = totals.total > 0 ? ((value / totals.total) * 100).toFixed(1) : '0.0';
+				return (
+					<Text key={name}>
+						<Text color={LEVEL_COLORS[name]}>{name.padEnd(8)}</Text>
+						{formatNumber(value).padStart(10)}{'   '}
+						<Text color={LEVEL_COLORS[name]}>{renderBar(value, totals.total, barWidth)}</Text>
+						{'  '}
+						<Text dimColor>{pct.padStart(5)}%</Text>
+					</Text>
+				);
+			})}
+			<Text> </Text>
+			<Text dimColor>q quit</Text>
+		</Box>
+	);
+}


### PR DESCRIPTION
## Summary
- Add `timberlogs stats` to show log volume and distribution
- Parallel API calls to `/v1/stats` and `/v1/stats/summary`
- Interactive `StatsView` with horizontal bars, level breakdown, and trend comparison
- `--group-by source` renders a per-source table
- `--json` mode with merged stats data

Closes #15