### PR TITLE
feat: root help text and polish

### DIFF
--- a/src/commands/index.tsx
+++ b/src/commands/index.tsx
@@ -4,7 +4,32 @@ export default function Index() {
 	return (
 		<Box flexDirection="column">
 			<Text bold>Timberlogs CLI v0.1.0</Text>
-			<Text>Run `timberlogs --help` for usage.</Text>
+			<Text> </Text>
+			<Text>Usage: timberlogs {'<command>'} [options]</Text>
+			<Text> </Text>
+			<Text bold>Commands:</Text>
+			<Text>  login              Store API key for authentication</Text>
+			<Text>  logout             Remove stored API key</Text>
+			<Text>  whoami             Show current auth status</Text>
+			<Text>  logs               Query and search logs</Text>
+			<Text>  flows show {'<id>'}    View a flow timeline</Text>
+			<Text>  stats              Show log volume and distribution</Text>
+			<Text>  config set         Set a config value</Text>
+			<Text>  config list        Show current config</Text>
+			<Text>  config reset       Delete config file</Text>
+			<Text> </Text>
+			<Text bold>Global Flags:</Text>
+			<Text>  --json             Force JSON output</Text>
+			<Text>  --api-key {'<key>'}    Override API key</Text>
+			<Text>  --api-url {'<url>'}    Override API endpoint</Text>
+			<Text>  --verbose          Show debug info</Text>
+			<Text>  --version, -v      Show version</Text>
+			<Text>  --help, -h         Show help</Text>
+			<Text> </Text>
+			<Text bold>Environment Variables:</Text>
+			<Text>  TIMBER_API_KEY     API key (overrides config file)</Text>
+			<Text>  TIMBER_API_URL     API endpoint (overrides config file)</Text>
+			<Text>  NO_COLOR           Disable color output</Text>
 		</Box>
 	);
 }


### PR DESCRIPTION
## Summary
- Add comprehensive root help text showing all commands, global flags, and environment variables
- Sub-command help auto-generated by Pastel from Zod option descriptions
- `--version` handled natively by Pastel/Commander

Closes #17