### PR TITLE
fix: pre-release audit fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,12 +30,12 @@
   },
   "scripts": {
     "build": "tsup",
-    "dev": "tsup --watch"
+    "dev": "tsup --watch",
+    "prepublishOnly": "pnpm build"
   },
   "dependencies": {
     "ink": "^5.2.0",
     "ink-text-input": "^6.0.0",
-    "ink-ui": "^0.4.0",
     "pastel": "^3.0.0",
     "react": "^18.3.1",
     "zod": "^3.25.76"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,6 @@ importers:
       ink-text-input:
         specifier: ^6.0.0
         version: 6.0.0(ink@5.2.1(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)
-      ink-ui:
-        specifier: ^0.4.0
-        version: 0.4.0
       pastel:
         specifier: ^3.0.0
         version: 3.0.0(ink@5.2.1(@types/react@18.3.28)(react@18.3.1))(react@18.3.1)(zod@3.25.76)
@@ -537,9 +534,6 @@ packages:
     peerDependencies:
       ink: '>=5'
       react: '>=18'
-
-  ink-ui@0.4.0:
-    resolution: {integrity: sha512-n9Zif1V/c3foSVCmbbU2/HUXwJFZpZUQlX1fowx1FQ8gCsHKXtokeHr+W4+oLnRoPK2ykT7m1D2UVPBKu8IgYg==}
 
   ink@5.2.1:
     resolution: {integrity: sha512-BqcUyWrG9zq5HIwW6JcfFHsIYebJkWWb4fczNah1goUO0vv5vneIlfwuS85twyJ5hYR/y18FlAYUxrO9ChIWVg==}
@@ -1200,8 +1194,6 @@ snapshots:
       ink: 5.2.1(@types/react@18.3.28)(react@18.3.1)
       react: 18.3.1
       type-fest: 4.41.0
-
-  ink-ui@0.4.0: {}
 
   ink@5.2.1(@types/react@18.3.28)(react@18.3.1):
     dependencies:

--- a/src/commands/config/set.tsx
+++ b/src/commands/config/set.tsx
@@ -3,6 +3,7 @@ import {useState, useEffect} from 'react';
 import {z} from 'zod';
 import {readConfig, writeConfig} from '../../lib/config.js';
 import {maskApiKey} from '../../lib/auth.js';
+import {handleError, CliError, ErrorCode} from '../../lib/errors.js';
 import type {Config} from '../../types/config.js';
 
 const VALID_KEYS: Record<string, keyof Config> = {
@@ -26,10 +27,9 @@ export default function ConfigSet({args: [key, value], options}: Props) {
 
 	useEffect(() => {
 		if (!configKey) {
-			const msg = `Invalid key: ${key}. Valid keys: ${Object.keys(VALID_KEYS).join(', ')}`;
+			const err = new CliError(ErrorCode.INVALID_INPUT, `Invalid key: ${key}. Valid keys: ${Object.keys(VALID_KEYS).join(', ')}`);
 			if (options.json) {
-				console.log(JSON.stringify({error: true, code: 'INVALID_INPUT', message: msg}));
-				process.exit(1);
+				handleError(err, true);
 			}
 
 			setResult({success: false});

--- a/src/commands/logout.tsx
+++ b/src/commands/logout.tsx
@@ -1,4 +1,4 @@
-import {Text} from 'ink';
+import {Text, Box} from 'ink';
 import {useEffect} from 'react';
 import {z} from 'zod';
 import {readConfig, writeConfig} from '../lib/config.js';
@@ -14,6 +14,7 @@ type Props = {
 export default function Logout({options}: Props) {
 	const config = readConfig();
 	const hadKey = Boolean(config.apiKey);
+	const hasEnvKey = Boolean(process.env['TIMBER_API_KEY']);
 
 	useEffect(() => {
 		if (hadKey) {
@@ -22,7 +23,7 @@ export default function Logout({options}: Props) {
 		}
 
 		if (options.json) {
-			console.log(JSON.stringify({loggedOut: true}));
+			console.log(JSON.stringify({loggedOut: true, envKeySet: hasEnvKey}));
 			process.exit(0);
 		}
 	}, []);
@@ -35,5 +36,12 @@ export default function Logout({options}: Props) {
 		return <Text color="yellow">No API key configured</Text>;
 	}
 
-	return <Text color="green">✓ Logged out — API key removed</Text>;
+	return (
+		<Box flexDirection="column">
+			<Text color="green">✓ Logged out — API key removed</Text>
+			{hasEnvKey && (
+				<Text color="yellow">Note: TIMBER_API_KEY env var is still set. Run `unset TIMBER_API_KEY` to fully log out.</Text>
+			)}
+		</Box>
+	);
 }

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -28,8 +28,13 @@ export function createApiClient(options: {
 				method,
 				headers,
 				body: body !== undefined ? JSON.stringify(body) : undefined,
+				signal: AbortSignal.timeout(30_000),
 			});
 		} catch (error) {
+			if (error instanceof DOMException && error.name === 'TimeoutError') {
+				throw new CliError(ErrorCode.NETWORK_ERROR, 'Request timed out after 30s');
+			}
+
 			if (error instanceof TypeError) {
 				throw new CliError(ErrorCode.NETWORK_ERROR, `Network error: ${error.message}`);
 			}

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -25,7 +25,7 @@ export function parseRelativeTime(input: string): number {
 	}
 
 	const numeric = Number(input);
-	if (!Number.isNaN(numeric)) {
+	if (!Number.isNaN(numeric) && numeric > 1e12) {
 		return numeric;
 	}
 


### PR DESCRIPTION
## Summary
- Add 30s network timeout to API client (prevents indefinite hangs)
- Validate numeric timestamps in time parser (reject values < 1e12)
- Use `CliError`/`handleError` in `config set` for consistent error format
- Warn about `TIMBER_API_KEY` env var on logout
- Add `prepublishOnly` script to ensure build before npm publish
- Remove unused `ink-ui` dependency (Vue library, not related to Ink)

Closes #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Logout command now displays a notice when TIMBER_API_KEY environment variable is still set
  * Logout command JSON output includes environment key status

* **Bug Fixes**
  * API requests now have a 30-second timeout with improved error handling
  * Invalid configuration keys now use structured error messages

* **Chores**
  * Removed ink-ui dependency
  * Added prepublishOnly build script

<!-- end of auto-generated comment: release notes by coderabbit.ai -->