### PR TITLE
fix: strip ANSI escape codes from stdout in JSON mode

### DIFF
--- a/src/cli.tsx
+++ b/src/cli.tsx
@@ -1,5 +1,31 @@
 import Pastel from 'pastel';
 
+// When --json is passed, Ink's renderer still writes ANSI escape codes to
+// stdout (cursor hide/show, erase line, etc.) even when components return null.
+// Strip those codes so piped JSON output stays clean.
+if (process.argv.includes('--json')) {
+	const origWrite = process.stdout.write.bind(process.stdout);
+	const ansiPattern =
+		// eslint-disable-next-line no-control-regex
+		/[\x1B\x9B][[()#;?]*(?:\d{1,4}(?:;\d{0,4})*)?[\dA-ORZcf-nq-uy=><~]/g;
+
+	process.stdout.write = function (
+		chunk: unknown,
+		...args: unknown[]
+	): boolean {
+		if (typeof chunk === 'string') {
+			const stripped = chunk.replace(ansiPattern, '');
+			if (stripped.length === 0) {
+				return true;
+			}
+
+			return origWrite(stripped, ...(args as []));
+		}
+
+		return origWrite(chunk as Uint8Array, ...(args as []));
+	} as typeof process.stdout.write;
+}
+
 const app = new Pastel({
 	importMeta: import.meta,
 	name: 'timberlogs',


### PR DESCRIPTION
## Summary
- Ink's renderer writes ANSI cursor management codes to stdout even when components return `null`, contaminating piped JSON output
- Intercepts `process.stdout.write` when `--json` is in argv to strip ANSI escape sequences before Pastel/Ink initializes
- Fixes `timberlogs logs --verbose --json 2>/dev/null | python3 -c "..."` failing with `JSONDecodeError`

## Test plan
- [x] `timberlogs logs --verbose --from 30m --limit 1 --json 2>/dev/null | python3 -c "import sys,json; json.load(sys.stdin)"` — passes
- [x] `timberlogs stats --json 2>/dev/null | python3 -c "import sys,json; json.load(sys.stdin)"` — passes
- [x] `timberlogs whoami --json 2>/dev/null | python3 -c "import sys,json; json.load(sys.stdin)"` — passes
- [x] Interactive (non-JSON) mode still renders correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * JSON output with the `--json` flag now produces clean data without formatting artifacts when piped or redirected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->