### PR TITLE
Add vitest test framework and unit tests for lib/

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "test": "vitest run",
     "prepublishOnly": "pnpm build"
   },
   "dependencies": {
@@ -44,6 +45,7 @@
     "@sindresorhus/tsconfig": "^7.0.0",
     "@types/react": "^18.3.18",
     "tsup": "^8.4.0",
-    "typescript": "^5.7.3"
+    "typescript": "^5.7.3",
+    "vitest": "^4.0.18"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,10 +32,13 @@ importers:
         version: 18.3.28
       tsup:
         specifier: ^8.4.0
-        version: 8.5.1(typescript@5.9.3)
+        version: 8.5.1(postcss@8.5.6)(typescript@5.9.3)
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
+      vitest:
+        specifier: ^4.0.18
+        version: 4.0.18
 
 packages:
 
@@ -355,6 +358,15 @@ packages:
     resolution: {integrity: sha512-i5K04hLAP44Af16zmDjG07E1NHuDgCM07SJAT4gY0LZSRrWYzwt4qkLem6TIbIVh0k51RkN2bF+lP+lM5eC9fw==}
     engines: {node: '>=18'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -366,6 +378,35 @@ packages:
 
   '@types/react@18.3.28':
     resolution: {integrity: sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==}
+
+  '@vitest/expect@4.0.18':
+    resolution: {integrity: sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==}
+
+  '@vitest/mocker@4.0.18':
+    resolution: {integrity: sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.0.18':
+    resolution: {integrity: sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==}
+
+  '@vitest/runner@4.0.18':
+    resolution: {integrity: sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==}
+
+  '@vitest/snapshot@4.0.18':
+    resolution: {integrity: sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==}
+
+  '@vitest/spy@4.0.18':
+    resolution: {integrity: sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==}
+
+  '@vitest/utils@4.0.18':
+    resolution: {integrity: sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==}
 
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
@@ -387,6 +428,10 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
   auto-bind@5.0.1:
     resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
@@ -400,6 +445,10 @@ packages:
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@5.6.2:
     resolution: {integrity: sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==}
@@ -475,6 +524,9 @@ packages:
     resolution: {integrity: sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==}
     engines: {node: '>=18'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-toolkit@1.44.0:
     resolution: {integrity: sha512-6penXeZalaV88MM3cGkFZZfOoLGWshWWfdy0tWw/RlVVyhvMaWSBTOvXNeiW3e5FwdS5ePW0LGEu17zT139ktg==}
 
@@ -486,6 +538,13 @@ packages:
   escape-string-regexp@2.0.0:
     resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
     engines: {node: '>=8'}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -610,6 +669,11 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   normalize-package-data@6.0.2:
     resolution: {integrity: sha512-V6gygoYb/5EmNI+MEGrWkC+e6+Rr7mTmfHrxDbLzxQogBkgzo76rkok0Am6thgSF7Mv2nLOajAJj5vDJZEFn7g==}
     engines: {node: ^16.14.0 || >=18.0.0}
@@ -617,6 +681,9 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
   onetime@5.1.2:
     resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
@@ -677,6 +744,10 @@ packages:
       yaml:
         optional: true
 
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
   react-reconciler@0.29.2:
     resolution: {integrity: sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==}
     engines: {node: '>=0.10.0'}
@@ -720,6 +791,9 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
 
@@ -730,6 +804,10 @@ packages:
   slice-ansi@7.1.2:
     resolution: {integrity: sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==}
     engines: {node: '>=18'}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
 
   source-map@0.7.6:
     resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
@@ -751,6 +829,12 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   string-width@7.2.0:
     resolution: {integrity: sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==}
     engines: {node: '>=18'}
@@ -771,12 +855,23 @@ packages:
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.0.3:
+    resolution: {integrity: sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==}
+    engines: {node: '>=14.0.0'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -822,6 +917,85 @@ packages:
 
   validate-npm-package-license@3.0.4:
     resolution: {integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==}
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.0.18:
+    resolution: {integrity: sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.0.18
+      '@vitest/browser-preview': 4.0.18
+      '@vitest/browser-webdriverio': 4.0.18
+      '@vitest/ui': 4.0.18
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
 
   widest-line@5.0.0:
     resolution: {integrity: sha512-c9bZp7b5YtRj2wOe6dlj32MK+Bx/M/d+9VB2SHM1OtsUHR0aV0tdP6DWh/iMt0kWi1t5g1Iudu6hQRNd1A4PVA==}
@@ -1047,6 +1221,15 @@ snapshots:
 
   '@sindresorhus/tsconfig@7.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
+  '@types/deep-eql@4.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/normalize-package-data@2.4.4': {}
@@ -1057,6 +1240,45 @@ snapshots:
     dependencies:
       '@types/prop-types': 15.7.15
       csstype: 3.2.3
+
+  '@vitest/expect@4.0.18':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      chai: 6.2.2
+      tinyrainbow: 3.0.3
+
+  '@vitest/mocker@4.0.18(vite@7.3.1)':
+    dependencies:
+      '@vitest/spy': 4.0.18
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.1
+
+  '@vitest/pretty-format@4.0.18':
+    dependencies:
+      tinyrainbow: 3.0.3
+
+  '@vitest/runner@4.0.18':
+    dependencies:
+      '@vitest/utils': 4.0.18
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.0.18': {}
+
+  '@vitest/utils@4.0.18':
+    dependencies:
+      '@vitest/pretty-format': 4.0.18
+      tinyrainbow: 3.0.3
 
   acorn@8.15.0: {}
 
@@ -1070,6 +1292,8 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  assertion-error@2.0.1: {}
+
   auto-bind@5.0.1: {}
 
   bundle-require@5.1.0(esbuild@0.27.3):
@@ -1078,6 +1302,8 @@ snapshots:
       load-tsconfig: 0.2.5
 
   cac@6.7.14: {}
+
+  chai@6.2.2: {}
 
   chalk@5.6.2: {}
 
@@ -1126,6 +1352,8 @@ snapshots:
 
   environment@1.1.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-toolkit@1.44.0: {}
 
   esbuild@0.27.3:
@@ -1158,6 +1386,12 @@ snapshots:
       '@esbuild/win32-x64': 0.27.3
 
   escape-string-regexp@2.0.0: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
+  expect-type@1.3.0: {}
 
   fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
@@ -1277,6 +1511,8 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
+  nanoid@3.3.11: {}
+
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
@@ -1284,6 +1520,8 @@ snapshots:
       validate-npm-package-license: 3.0.4
 
   object-assign@4.1.1: {}
+
+  obug@2.1.1: {}
 
   onetime@5.1.2:
     dependencies:
@@ -1327,9 +1565,17 @@ snapshots:
     dependencies:
       irregular-plurals: 3.5.0
 
-  postcss-load-config@6.0.1:
+  postcss-load-config@6.0.1(postcss@8.5.6):
     dependencies:
       lilconfig: 3.1.3
+    optionalDependencies:
+      postcss: 8.5.6
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   react-reconciler@0.29.2(react@18.3.1):
     dependencies:
@@ -1401,6 +1647,8 @@ snapshots:
 
   semver@7.7.4: {}
 
+  siginfo@2.0.0: {}
+
   signal-exit@3.0.7: {}
 
   slice-ansi@5.0.0:
@@ -1412,6 +1660,8 @@ snapshots:
     dependencies:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
+
+  source-map-js@1.2.1: {}
 
   source-map@0.7.6: {}
 
@@ -1432,6 +1682,10 @@ snapshots:
   stack-utils@2.0.6:
     dependencies:
       escape-string-regexp: 2.0.0
+
+  stackback@0.0.2: {}
+
+  std-env@3.10.0: {}
 
   string-width@7.2.0:
     dependencies:
@@ -1461,18 +1715,24 @@ snapshots:
     dependencies:
       any-promise: 1.3.0
 
+  tinybench@2.9.0: {}
+
   tinyexec@0.3.2: {}
+
+  tinyexec@1.0.2: {}
 
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tinyrainbow@3.0.3: {}
+
   tree-kill@1.2.2: {}
 
   ts-interface-checker@0.1.13: {}
 
-  tsup@8.5.1(typescript@5.9.3):
+  tsup@8.5.1(postcss@8.5.6)(typescript@5.9.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.3)
       cac: 6.7.14
@@ -1483,7 +1743,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1
+      postcss-load-config: 6.0.1(postcss@8.5.6)
       resolve-from: 5.0.0
       rollup: 4.57.1
       source-map: 0.7.6
@@ -1492,6 +1752,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
+      postcss: 8.5.6
       typescript: 5.9.3
     transitivePeerDependencies:
       - jiti
@@ -1511,6 +1772,57 @@ snapshots:
     dependencies:
       spdx-correct: 3.2.0
       spdx-expression-parse: 3.0.1
+
+  vite@7.3.1:
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  vitest@4.0.18:
+    dependencies:
+      '@vitest/expect': 4.0.18
+      '@vitest/mocker': 4.0.18(vite@7.3.1)
+      '@vitest/pretty-format': 4.0.18
+      '@vitest/runner': 4.0.18
+      '@vitest/snapshot': 4.0.18
+      '@vitest/spy': 4.0.18
+      '@vitest/utils': 4.0.18
+      es-module-lexer: 1.7.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
+      pathe: 2.0.3
+      picomatch: 4.0.3
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.0.3
+      vite: 7.3.1
+      why-is-node-running: 2.3.0
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - terser
+      - tsx
+      - yaml
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   widest-line@5.0.0:
     dependencies:

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,79 @@
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {resolveApiKey, requireApiKey, maskApiKey} from '../auth.js';
+import {CliError} from '../errors.js';
+
+vi.mock('../config.js', () => ({
+	readConfig: vi.fn(() => ({})),
+}));
+
+import {readConfig} from '../config.js';
+
+const mockedReadConfig = vi.mocked(readConfig);
+
+describe('resolveApiKey', () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = {...originalEnv};
+		delete process.env['TIMBER_API_KEY'];
+		mockedReadConfig.mockReturnValue({});
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('returns flag value first', () => {
+		process.env['TIMBER_API_KEY'] = 'env-key';
+		mockedReadConfig.mockReturnValue({apiKey: 'config-key'});
+		expect(resolveApiKey({apiKey: 'flag-key'})).toBe('flag-key');
+	});
+
+	it('falls back to env var', () => {
+		process.env['TIMBER_API_KEY'] = 'env-key';
+		mockedReadConfig.mockReturnValue({apiKey: 'config-key'});
+		expect(resolveApiKey({})).toBe('env-key');
+	});
+
+	it('falls back to config file', () => {
+		mockedReadConfig.mockReturnValue({apiKey: 'config-key'});
+		expect(resolveApiKey({})).toBe('config-key');
+	});
+
+	it('returns null when no key found', () => {
+		expect(resolveApiKey({})).toBeNull();
+	});
+});
+
+describe('requireApiKey', () => {
+	beforeEach(() => {
+		const originalEnv = process.env;
+		process.env = {...originalEnv};
+		delete process.env['TIMBER_API_KEY'];
+		mockedReadConfig.mockReturnValue({});
+	});
+
+	it('returns key when available', () => {
+		expect(requireApiKey({apiKey: 'test-key'})).toBe('test-key');
+	});
+
+	it('throws CliError when no key', () => {
+		expect(() => requireApiKey({})).toThrow(CliError);
+		expect(() => requireApiKey({})).toThrow('No API key found');
+	});
+});
+
+describe('maskApiKey', () => {
+	it('masks normal length keys', () => {
+		expect(maskApiKey('tb_live_abcdefghijklmnop1234')).toBe('tb_live_****...1234');
+	});
+
+	it('masks keys of exactly 16 chars', () => {
+		expect(maskApiKey('1234567890123456')).toBe('12345678****...3456');
+	});
+
+	it('returns **** for short keys', () => {
+		expect(maskApiKey('short')).toBe('****');
+		expect(maskApiKey('')).toBe('****');
+	});
+});

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -1,0 +1,80 @@
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {readConfig, writeConfig, deleteConfig, getConfigDir, getConfigPath} from '../config.js';
+import {mkdtempSync, rmSync, existsSync, readFileSync, statSync} from 'node:fs';
+import {join} from 'node:path';
+import {tmpdir} from 'node:os';
+
+describe('config', () => {
+	let tmpDir: string;
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		tmpDir = mkdtempSync(join(tmpdir(), 'timberlogs-test-'));
+		process.env = {...originalEnv, TIMBERLOGS_CONFIG_DIR: tmpDir};
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+		rmSync(tmpDir, {recursive: true, force: true});
+	});
+
+	describe('getConfigDir', () => {
+		it('returns env var when set', () => {
+			expect(getConfigDir()).toBe(tmpDir);
+		});
+
+		it('returns default when env not set', () => {
+			delete process.env['TIMBERLOGS_CONFIG_DIR'];
+			const dir = getConfigDir();
+			expect(dir).toContain('.config/timberlogs');
+		});
+	});
+
+	describe('getConfigPath', () => {
+		it('returns config.json in config dir', () => {
+			expect(getConfigPath()).toBe(join(tmpDir, 'config.json'));
+		});
+	});
+
+	describe('readConfig', () => {
+		it('returns empty object when no config file', () => {
+			expect(readConfig()).toEqual({});
+		});
+
+		it('reads existing config', () => {
+			writeConfig({apiKey: 'test-key', apiUrl: 'https://example.com'});
+			expect(readConfig()).toEqual({apiKey: 'test-key', apiUrl: 'https://example.com'});
+		});
+	});
+
+	describe('writeConfig', () => {
+		it('creates config file', () => {
+			writeConfig({apiKey: 'test'});
+			const path = getConfigPath();
+			expect(existsSync(path)).toBe(true);
+			const content = JSON.parse(readFileSync(path, 'utf-8'));
+			expect(content).toEqual({apiKey: 'test'});
+		});
+
+		it('sets secure file permissions', () => {
+			writeConfig({apiKey: 'test'});
+			const path = getConfigPath();
+			const stats = statSync(path);
+			expect(stats.mode & 0o777).toBe(0o600);
+		});
+	});
+
+	describe('deleteConfig', () => {
+		it('deletes existing config file', () => {
+			writeConfig({apiKey: 'test'});
+			const path = getConfigPath();
+			expect(existsSync(path)).toBe(true);
+			deleteConfig();
+			expect(existsSync(path)).toBe(false);
+		});
+
+		it('does not throw when no config file', () => {
+			expect(() => deleteConfig()).not.toThrow();
+		});
+	});
+});

--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,71 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {CliError, ErrorCode, formatError, handleError} from '../errors.js';
+
+describe('CliError', () => {
+	it('sets code and exit code', () => {
+		const err = new CliError(ErrorCode.AUTH_REQUIRED, 'No key');
+		expect(err.code).toBe('AUTH_REQUIRED');
+		expect(err.exitCode).toBe(2);
+		expect(err.message).toBe('No key');
+		expect(err.name).toBe('CliError');
+	});
+
+	it('sets exit code 1 for network errors', () => {
+		const err = new CliError(ErrorCode.NETWORK_ERROR, 'timeout');
+		expect(err.exitCode).toBe(1);
+	});
+
+	it('sets exit code 2 for auth errors', () => {
+		const err = new CliError(ErrorCode.AUTH_INVALID, 'bad key');
+		expect(err.exitCode).toBe(2);
+	});
+});
+
+describe('formatError', () => {
+	it('formats CliError to object', () => {
+		const err = new CliError(ErrorCode.NOT_FOUND, 'Log not found');
+		expect(formatError(err)).toEqual({
+			error: true,
+			code: 'NOT_FOUND',
+			message: 'Log not found',
+		});
+	});
+});
+
+describe('handleError', () => {
+	let exitSpy: ReturnType<typeof vi.spyOn>;
+	let consoleSpy: ReturnType<typeof vi.spyOn>;
+	let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+	beforeEach(() => {
+		exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+		consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+	});
+
+	it('outputs JSON for CliError in json mode', () => {
+		const err = new CliError(ErrorCode.AUTH_REQUIRED, 'No key');
+		handleError(err, true);
+		expect(consoleSpy).toHaveBeenCalledWith(JSON.stringify({error: true, code: 'AUTH_REQUIRED', message: 'No key'}));
+		expect(exitSpy).toHaveBeenCalledWith(2);
+	});
+
+	it('outputs colored text for CliError in interactive mode', () => {
+		const err = new CliError(ErrorCode.NETWORK_ERROR, 'timeout');
+		handleError(err, false);
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('timeout'));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('handles non-CliError in json mode', () => {
+		handleError(new Error('unexpected'), true);
+		expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('unexpected'));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+
+	it('handles non-CliError in interactive mode', () => {
+		handleError('string error', false);
+		expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('string error'));
+		expect(exitSpy).toHaveBeenCalledWith(1);
+	});
+});

--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -1,0 +1,38 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {isJsonMode, jsonOutput} from '../output.js';
+
+describe('isJsonMode', () => {
+	it('returns true when --json flag is set', () => {
+		expect(isJsonMode({json: true})).toBe(true);
+	});
+
+	it('returns false when --interactive flag is set', () => {
+		expect(isJsonMode({interactive: true})).toBe(false);
+	});
+
+	it('--json takes precedence over --interactive', () => {
+		expect(isJsonMode({json: true, interactive: true})).toBe(true);
+	});
+
+	it('falls back to TTY detection', () => {
+		const originalIsTTY = process.stdout.isTTY;
+		Object.defineProperty(process.stdout, 'isTTY', {value: true, writable: true});
+		expect(isJsonMode({})).toBe(false);
+		Object.defineProperty(process.stdout, 'isTTY', {value: false, writable: true});
+		expect(isJsonMode({})).toBe(true);
+		Object.defineProperty(process.stdout, 'isTTY', {value: originalIsTTY, writable: true});
+	});
+});
+
+describe('jsonOutput', () => {
+	beforeEach(() => {
+		vi.spyOn(process, 'exit').mockImplementation(() => undefined as never);
+		vi.spyOn(console, 'log').mockImplementation(() => {});
+	});
+
+	it('outputs JSON and exits', () => {
+		jsonOutput({foo: 'bar'});
+		expect(console.log).toHaveBeenCalledWith('{"foo":"bar"}');
+		expect(process.exit).toHaveBeenCalledWith(0);
+	});
+});

--- a/src/lib/__tests__/time.test.ts
+++ b/src/lib/__tests__/time.test.ts
@@ -1,0 +1,56 @@
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {parseRelativeTime} from '../time.js';
+import {CliError} from '../errors.js';
+
+describe('parseRelativeTime', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		vi.setSystemTime(new Date('2026-02-19T12:00:00Z'));
+	});
+
+	it('parses minutes', () => {
+		const result = parseRelativeTime('30m');
+		expect(result).toBe(Date.now() - 30 * 60 * 1000);
+	});
+
+	it('parses hours', () => {
+		const result = parseRelativeTime('1h');
+		expect(result).toBe(Date.now() - 60 * 60 * 1000);
+	});
+
+	it('parses days', () => {
+		const result = parseRelativeTime('7d');
+		expect(result).toBe(Date.now() - 7 * 24 * 60 * 60 * 1000);
+	});
+
+	it('parses weeks', () => {
+		const result = parseRelativeTime('2w');
+		expect(result).toBe(Date.now() - 2 * 7 * 24 * 60 * 60 * 1000);
+	});
+
+	it('parses ISO 8601 strings', () => {
+		const result = parseRelativeTime('2026-02-18T14:00:00Z');
+		expect(result).toBe(new Date('2026-02-18T14:00:00Z').getTime());
+	});
+
+	it('parses numeric timestamps', () => {
+		const ts = 1771500000000;
+		const result = parseRelativeTime(String(ts));
+		expect(result).toBe(ts);
+	});
+
+	it('treats small numeric strings as dates if parseable', () => {
+		// '12345' is parsed as a year by Date constructor, so it returns a valid timestamp
+		const result = parseRelativeTime('12345');
+		expect(result).toBe(new Date('12345').getTime());
+	});
+
+	it('rejects invalid input', () => {
+		expect(() => parseRelativeTime('abc')).toThrow(CliError);
+		expect(() => parseRelativeTime('abc')).toThrow('Invalid time format');
+	});
+
+	it('rejects empty string', () => {
+		expect(() => parseRelativeTime('')).toThrow(CliError);
+	});
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -16,6 +16,8 @@ export default defineConfig([
 			'src/lib/**/*.ts',
 			'src/types/**/*.ts',
 			'src/components/**/*.tsx',
+			'!src/**/__tests__/**',
+			'!src/**/*.test.*',
 		],
 		format: 'esm',
 		target: 'node20',


### PR DESCRIPTION
## Summary
- Add vitest as test framework with `pnpm test` script
- 40 unit tests across 5 test files covering all lib/ functions:
  - `time.test.ts` — parseRelativeTime (relative, ISO, numeric, invalid)
  - `auth.test.ts` — resolveApiKey fallback chain, requireApiKey, maskApiKey
  - `config.test.ts` — readConfig, writeConfig, deleteConfig, permissions
  - `errors.test.ts` — CliError, formatError, handleError (JSON + interactive)
  - `output.test.ts` — isJsonMode, jsonOutput
- Exclude test files from tsup build output

Closes #25

## Test plan
- [x] `pnpm test` — 40 tests pass
- [x] `pnpm build` — no test files in dist/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for authentication, configuration management, error handling, output formatting, and time parsing utilities to improve code reliability and maintainability.
  * Configured test infrastructure to exclude test files from production builds, ensuring cleaner deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->