### PR TITLE
Read version from package.json at build time

### DIFF
--- a/src/commands/index.tsx
+++ b/src/commands/index.tsx
@@ -3,7 +3,7 @@ import {Text, Box} from 'ink';
 export default function Index() {
 	return (
 		<Box flexDirection="column">
-			<Text bold>Timberlogs CLI v0.1.0</Text>
+			<Text bold>Timberlogs CLI v{CLI_VERSION}</Text>
 			<Text> </Text>
 			<Text>Usage: timberlogs {'<command>'} [options]</Text>
 			<Text> </Text>

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,1 @@
+declare const CLI_VERSION: string;

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,8 @@
 import {defineConfig} from 'tsup';
+import {createRequire} from 'node:module';
+
+const require = createRequire(import.meta.url);
+const {version} = require('./package.json') as {version: string};
 
 export default defineConfig([
 	{
@@ -8,6 +12,7 @@ export default defineConfig([
 		banner: {js: '#!/usr/bin/env node'},
 		outDir: 'dist',
 		clean: true,
+		define: {'CLI_VERSION': JSON.stringify(version)},
 	},
 	{
 		entry: [
@@ -24,5 +29,6 @@ export default defineConfig([
 		outDir: 'dist',
 		bundle: false,
 		clean: false,
+		define: {'CLI_VERSION': JSON.stringify(version)},
 	},
 ]);


### PR DESCRIPTION
Closes #27. Uses tsup `define` to inject version from package.json.