### PR TITLE
Add enum validation for --level and --group-by flags

### DIFF
--- a/src/commands/logs.tsx
+++ b/src/commands/logs.tsx
@@ -10,7 +10,7 @@ import type {LogsResponse} from '../types/log.js';
 import LogTable from '../components/LogTable.js';
 
 export const options = z.object({
-	level: z.string().optional().describe('Filter by level (debug|info|warn|error)'),
+	level: z.enum(['debug', 'info', 'warn', 'error']).optional().describe('Filter by level (debug|info|warn|error)'),
 	source: z.string().optional().describe('Filter by source'),
 	env: z.string().optional().describe('Filter by environment'),
 	search: z.string().optional().describe('Full-text search query'),

--- a/src/commands/stats.tsx
+++ b/src/commands/stats.tsx
@@ -11,7 +11,7 @@ import StatsView from '../components/StatsView.js';
 export const options = z.object({
 	from: z.string().default('24h').describe('Start time (e.g., 24h, 7d)'),
 	to: z.string().optional().describe('End time'),
-	'group-by': z.string().default('day').describe('Group by: hour, day, source'),
+	'group-by': z.enum(['hour', 'day', 'source']).default('day').describe('Group by: hour, day, source'),
 	source: z.string().optional().describe('Filter by source'),
 	env: z.string().optional().describe('Filter by environment'),
 	dataset: z.string().optional().describe('Filter by dataset'),


### PR DESCRIPTION
## Summary
- Replaced loose `z.string()` with `z.enum()` for `--level` flag in logs command and `--group-by` flag in stats command
- Pastel/Zod will now reject invalid values at parse time with a clear error message

Closes #28