### PR TITLE
Add runtime validation of API responses

### DIFF
--- a/src/commands/flows/show.tsx
+++ b/src/commands/flows/show.tsx
@@ -6,7 +6,7 @@ import {createApiClient} from '../../lib/api.js';
 import {resolveApiUrl} from '../../lib/time.js';
 import {handleError} from '../../lib/errors.js';
 import {isJsonMode, jsonOutput} from '../../lib/output.js';
-import type {LogsResponse} from '../../types/log.js';
+import {LogsResponseSchema, type LogsResponse} from '../../types/log.js';
 import FlowTimeline from '../../components/FlowTimeline.js';
 
 export const args = z.tuple([z.string().describe('flowId')]);
@@ -46,10 +46,11 @@ export default function FlowsShow({args: [flowId], options: flags}: Props) {
 			const baseUrl = resolveApiUrl({apiUrl: flags['api-url']});
 			const client = createApiClient({apiKey, baseUrl, verbose: flags.verbose});
 
-			const response = await client.get<LogsResponse>('/v1/logs', {
+			const raw = await client.get('/v1/logs', {
 				flowId,
 				limit: 1000,
 			});
+			const response = LogsResponseSchema.parse(raw);
 
 			const logs = response.logs;
 			const stepCount = logs.length;

--- a/src/commands/logs.tsx
+++ b/src/commands/logs.tsx
@@ -6,7 +6,7 @@ import {createApiClient} from '../lib/api.js';
 import {resolveApiUrl, parseRelativeTime} from '../lib/time.js';
 import {handleError} from '../lib/errors.js';
 import {isJsonMode, jsonOutput} from '../lib/output.js';
-import type {LogsResponse} from '../types/log.js';
+import {LogsResponseSchema, type LogsResponse} from '../types/log.js';
 import LogTable from '../components/LogTable.js';
 
 export const options = z.object({
@@ -64,16 +64,18 @@ export default function Logs({options: flags}: Props) {
 				dataset: flags.dataset,
 			};
 
-			let response: LogsResponse;
+			let raw: unknown;
 
 			if (flags.search) {
-				response = await client.get<LogsResponse>('/v1/logs/search', {
+				raw = await client.get('/v1/logs/search', {
 					q: flags.search,
 					...params,
 				});
 			} else {
-				response = await client.get<LogsResponse>('/v1/logs', params);
+				raw = await client.get('/v1/logs', params);
 			}
+
+			const response = LogsResponseSchema.parse(raw);
 
 			if (json) {
 				jsonOutput(response);

--- a/src/commands/stats.tsx
+++ b/src/commands/stats.tsx
@@ -6,6 +6,7 @@ import {createApiClient} from '../lib/api.js';
 import {resolveApiUrl, parseRelativeTime} from '../lib/time.js';
 import {handleError} from '../lib/errors.js';
 import {isJsonMode, jsonOutput} from '../lib/output.js';
+import {StatsResponseSchema, StatsSummaryResponseSchema} from '../types/log.js';
 import StatsView from '../components/StatsView.js';
 
 export const options = z.object({
@@ -58,15 +59,17 @@ export default function Stats({options: flags}: Props) {
 			const toDate = toDateString(toMs);
 
 			const [statsResponse, summaryResponse] = await Promise.all([
-				client.get<{stats: unknown[]; totals?: Record<string, number>}>('/v1/stats', {
+				client.get('/v1/stats', {
 					from: fromDate,
 					to: toDate,
 					groupBy: flags['group-by'],
 					source: flags.source,
 					environment: flags.env,
 					dataset: flags.dataset,
-				}),
-				client.get<{today?: number; yesterday?: number; totals?: Record<string, number>}>('/v1/stats/summary').catch(() => null),
+				}).then(raw => StatsResponseSchema.parse(raw)),
+				client.get('/v1/stats/summary')
+					.then(raw => StatsSummaryResponseSchema.parse(raw))
+					.catch(() => null),
 			]);
 
 			const totals = {

--- a/src/types/log.ts
+++ b/src/types/log.ts
@@ -1,29 +1,47 @@
-export interface LogEntry {
-	id: string;
-	level: 'debug' | 'info' | 'warn' | 'error';
-	message: string;
-	timestamp: string;
-	source?: string;
-	environment?: string;
-	dataset?: string;
-	version?: string;
-	userId?: string;
-	sessionId?: string;
-	requestId?: string;
-	flowId?: string;
-	stepIndex?: number;
-	tags?: string[];
-	data?: Record<string, unknown>;
-	errorName?: string;
-	errorStack?: string;
-}
+import {z} from 'zod';
 
-export interface LogsResponse {
-	logs: LogEntry[];
-	pagination: {
-		total: number;
-		offset: number;
-		limit: number;
-		hasMore: boolean;
-	};
-}
+export const LogEntrySchema = z.object({
+	id: z.string(),
+	level: z.enum(['debug', 'info', 'warn', 'error']),
+	message: z.string(),
+	timestamp: z.string(),
+	source: z.string().optional(),
+	environment: z.string().optional(),
+	dataset: z.string().optional(),
+	version: z.string().optional(),
+	userId: z.string().optional(),
+	sessionId: z.string().optional(),
+	requestId: z.string().optional(),
+	flowId: z.string().optional(),
+	stepIndex: z.number().optional(),
+	tags: z.array(z.string()).optional(),
+	data: z.record(z.unknown()).optional(),
+	errorName: z.string().optional(),
+	errorStack: z.string().optional(),
+});
+
+export const LogsResponseSchema = z.object({
+	logs: z.array(LogEntrySchema),
+	pagination: z.object({
+		total: z.number(),
+		offset: z.number(),
+		limit: z.number(),
+		hasMore: z.boolean(),
+	}),
+});
+
+export const StatsResponseSchema = z.object({
+	stats: z.array(z.record(z.unknown())),
+	totals: z.record(z.number()).optional(),
+});
+
+export const StatsSummaryResponseSchema = z.object({
+	today: z.number().optional(),
+	yesterday: z.number().optional(),
+	totals: z.record(z.number()).optional(),
+});
+
+export type LogEntry = z.infer<typeof LogEntrySchema>;
+export type LogsResponse = z.infer<typeof LogsResponseSchema>;
+export type StatsResponse = z.infer<typeof StatsResponseSchema>;
+export type StatsSummaryResponse = z.infer<typeof StatsSummaryResponseSchema>;


### PR DESCRIPTION
## Summary
- Added Zod schemas for `LogsResponse`, `StatsResponse`, and `StatsSummaryResponse` in `types/log.ts`
- Logs, flows show, and stats commands now validate API responses at runtime
- Catches malformed or unexpected responses early with clear Zod error messages

Closes #30