### PR TITLE
Move resolveApiUrl from time.ts to auth.ts

### DIFF
--- a/src/commands/flows/show.tsx
+++ b/src/commands/flows/show.tsx
@@ -1,9 +1,8 @@
 import {Text} from 'ink';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
-import {requireApiKey} from '../../lib/auth.js';
+import {requireApiKey, resolveApiUrl} from '../../lib/auth.js';
 import {createApiClient} from '../../lib/api.js';
-import {resolveApiUrl} from '../../lib/time.js';
 import {handleError} from '../../lib/errors.js';
 import {isJsonMode, jsonOutput} from '../../lib/output.js';
 import {LogsResponseSchema, type LogsResponse} from '../../types/log.js';

--- a/src/commands/login.tsx
+++ b/src/commands/login.tsx
@@ -3,9 +3,8 @@ import TextInput from 'ink-text-input';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
 import {readConfig, writeConfig} from '../lib/config.js';
-import {maskApiKey} from '../lib/auth.js';
+import {maskApiKey, resolveApiUrl} from '../lib/auth.js';
 import {createApiClient} from '../lib/api.js';
-import {resolveApiUrl} from '../lib/time.js';
 import {handleError} from '../lib/errors.js';
 
 export const options = z.object({

--- a/src/commands/logs.tsx
+++ b/src/commands/logs.tsx
@@ -1,9 +1,9 @@
 import {Text} from 'ink';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
-import {requireApiKey} from '../lib/auth.js';
+import {requireApiKey, resolveApiUrl} from '../lib/auth.js';
 import {createApiClient} from '../lib/api.js';
-import {resolveApiUrl, parseRelativeTime} from '../lib/time.js';
+import {parseRelativeTime} from '../lib/time.js';
 import {handleError} from '../lib/errors.js';
 import {isJsonMode, jsonOutput} from '../lib/output.js';
 import {LogsResponseSchema, type LogsResponse} from '../types/log.js';

--- a/src/commands/stats.tsx
+++ b/src/commands/stats.tsx
@@ -1,9 +1,9 @@
 import {Text} from 'ink';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
-import {requireApiKey} from '../lib/auth.js';
+import {requireApiKey, resolveApiUrl} from '../lib/auth.js';
 import {createApiClient} from '../lib/api.js';
-import {resolveApiUrl, parseRelativeTime} from '../lib/time.js';
+import {parseRelativeTime} from '../lib/time.js';
 import {handleError} from '../lib/errors.js';
 import {isJsonMode, jsonOutput} from '../lib/output.js';
 import {StatsResponseSchema, StatsSummaryResponseSchema} from '../types/log.js';

--- a/src/commands/whoami.tsx
+++ b/src/commands/whoami.tsx
@@ -1,9 +1,8 @@
 import {Text, Box} from 'ink';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
-import {resolveApiKey, maskApiKey} from '../lib/auth.js';
+import {resolveApiKey, maskApiKey, resolveApiUrl} from '../lib/auth.js';
 import {createApiClient} from '../lib/api.js';
-import {resolveApiUrl} from '../lib/time.js';
 import {handleError, CliError, ErrorCode} from '../lib/errors.js';
 
 export const options = z.object({

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {resolveApiKey, requireApiKey, maskApiKey} from '../auth.js';
+import {resolveApiKey, requireApiKey, maskApiKey, resolveApiUrl} from '../auth.js';
 import {CliError} from '../errors.js';
 
 vi.mock('../config.js', () => ({
@@ -60,6 +60,40 @@ describe('requireApiKey', () => {
 	it('throws CliError when no key', () => {
 		expect(() => requireApiKey({})).toThrow(CliError);
 		expect(() => requireApiKey({})).toThrow('No API key found');
+	});
+});
+
+describe('resolveApiUrl', () => {
+	const originalEnv = process.env;
+
+	beforeEach(() => {
+		process.env = {...originalEnv};
+		delete process.env['TIMBER_API_URL'];
+		mockedReadConfig.mockReturnValue({});
+	});
+
+	afterEach(() => {
+		process.env = originalEnv;
+	});
+
+	it('returns flag value first', () => {
+		process.env['TIMBER_API_URL'] = 'https://env.example.com';
+		mockedReadConfig.mockReturnValue({apiUrl: 'https://config.example.com'});
+		expect(resolveApiUrl({apiUrl: 'https://flag.example.com'})).toBe('https://flag.example.com');
+	});
+
+	it('falls back to env var', () => {
+		process.env['TIMBER_API_URL'] = 'https://env.example.com';
+		expect(resolveApiUrl({})).toBe('https://env.example.com');
+	});
+
+	it('falls back to config file', () => {
+		mockedReadConfig.mockReturnValue({apiUrl: 'https://config.example.com'});
+		expect(resolveApiUrl({})).toBe('https://config.example.com');
+	});
+
+	it('returns default URL when nothing set', () => {
+		expect(resolveApiUrl({})).toBe('https://timberlogs-ingest.enaboapps.workers.dev');
 	});
 });
 

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import {readConfig} from './config.js';
 import {CliError, ErrorCode} from './errors.js';
+import {DEFAULT_API_URL} from '../types/config.js';
 
 export function resolveApiKey(flags: {apiKey?: string}): string | null {
 	if (flags.apiKey) {
@@ -29,6 +30,24 @@ export function requireApiKey(flags: {apiKey?: string}): string {
 	}
 
 	return key;
+}
+
+export function resolveApiUrl(flags: {apiUrl?: string}): string {
+	if (flags.apiUrl) {
+		return flags.apiUrl;
+	}
+
+	const envUrl = process.env['TIMBER_API_URL'];
+	if (envUrl) {
+		return envUrl;
+	}
+
+	const config = readConfig();
+	if (config.apiUrl) {
+		return config.apiUrl;
+	}
+
+	return DEFAULT_API_URL;
 }
 
 export function maskApiKey(key: string): string {

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,6 +1,4 @@
-import {readConfig} from './config.js';
 import {CliError, ErrorCode} from './errors.js';
-import {DEFAULT_API_URL} from '../types/config.js';
 
 const MULTIPLIERS: Record<string, number> = {
 	m: 60 * 1000,
@@ -33,22 +31,4 @@ export function parseRelativeTime(input: string): number {
 		ErrorCode.INVALID_INPUT,
 		`Invalid time format: ${input}. Use 30m, 1h, 24h, 7d, or ISO 8601.`,
 	);
-}
-
-export function resolveApiUrl(flags: {apiUrl?: string}): string {
-	if (flags.apiUrl) {
-		return flags.apiUrl;
-	}
-
-	const envUrl = process.env['TIMBER_API_URL'];
-	if (envUrl) {
-		return envUrl;
-	}
-
-	const config = readConfig();
-	if (config.apiUrl) {
-		return config.apiUrl;
-	}
-
-	return DEFAULT_API_URL;
 }


### PR DESCRIPTION
## Summary
- Moved `resolveApiUrl` from `time.ts` to `auth.ts` where it logically belongs (same resolution pattern as `resolveApiKey`)
- Updated all imports across commands
- Added 4 tests for `resolveApiUrl` in auth test suite

Closes #32