### PR TITLE
Extract shared LEVEL_COLORS and formatTime

### DIFF
--- a/src/components/FlowTimeline.tsx
+++ b/src/components/FlowTimeline.tsx
@@ -1,5 +1,6 @@
 import {Text, Box, useInput} from 'ink';
 import type {LogEntry} from '../types/log.js';
+import {LEVEL_COLORS, formatTime} from '../lib/format.js';
 
 type Props = {
 	flowId: string;
@@ -8,22 +9,6 @@ type Props = {
 	durationMs: number;
 	hasErrors: boolean;
 };
-
-const LEVEL_COLORS: Record<string, string> = {
-	debug: 'gray',
-	info: 'blue',
-	warn: 'yellow',
-	error: 'red',
-};
-
-function formatTime(timestamp: string): string {
-	const d = new Date(timestamp);
-	const h = String(d.getHours()).padStart(2, '0');
-	const m = String(d.getMinutes()).padStart(2, '0');
-	const s = String(d.getSeconds()).padStart(2, '0');
-	const ms = String(d.getMilliseconds()).padStart(3, '0');
-	return `${h}:${m}:${s}.${ms}`;
-}
 
 function formatDuration(ms: number): string {
 	if (ms < 1000) return `${ms}ms`;

--- a/src/components/LogDetail.tsx
+++ b/src/components/LogDetail.tsx
@@ -1,15 +1,9 @@
 import {Text, Box} from 'ink';
 import type {LogEntry} from '../types/log.js';
+import {LEVEL_COLORS} from '../lib/format.js';
 
 type Props = {
 	log: LogEntry;
-};
-
-const LEVEL_COLORS: Record<string, string> = {
-	debug: 'gray',
-	info: 'blue',
-	warn: 'yellow',
-	error: 'red',
 };
 
 function Field({label, value}: {label: string; value: string | undefined}) {

--- a/src/components/LogTable.tsx
+++ b/src/components/LogTable.tsx
@@ -1,6 +1,7 @@
 import {Text, Box, useInput} from 'ink';
 import {useState} from 'react';
 import type {LogEntry, LogsResponse} from '../types/log.js';
+import {LEVEL_COLORS, formatTime} from '../lib/format.js';
 import LogDetail from './LogDetail.js';
 
 type Props = {
@@ -8,22 +9,6 @@ type Props = {
 	pagination: LogsResponse['pagination'];
 	filterSummary?: string;
 };
-
-const LEVEL_COLORS: Record<string, string> = {
-	debug: 'gray',
-	info: 'blue',
-	warn: 'yellow',
-	error: 'red',
-};
-
-function formatTime(timestamp: string): string {
-	const d = new Date(timestamp);
-	const h = String(d.getHours()).padStart(2, '0');
-	const m = String(d.getMinutes()).padStart(2, '0');
-	const s = String(d.getSeconds()).padStart(2, '0');
-	const ms = String(d.getMilliseconds()).padStart(3, '0');
-	return `${h}:${m}:${s}.${ms}`;
-}
 
 export default function LogTable({logs, pagination, filterSummary}: Props) {
 	const [cursor, setCursor] = useState(0);

--- a/src/components/StatsView.tsx
+++ b/src/components/StatsView.tsx
@@ -1,4 +1,5 @@
 import {Text, Box, useInput} from 'ink';
+import {LEVEL_COLORS} from '../lib/format.js';
 
 type LevelStats = {
 	debug: number;
@@ -24,13 +25,6 @@ type Props = {
 		warn: number;
 		error: number;
 	}>;
-};
-
-const LEVEL_COLORS: Record<string, string> = {
-	debug: 'gray',
-	info: 'blue',
-	warn: 'yellow',
-	error: 'red',
 };
 
 function formatNumber(n: number): string {

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -1,0 +1,15 @@
+export const LEVEL_COLORS: Record<string, string> = {
+	debug: 'gray',
+	info: 'blue',
+	warn: 'yellow',
+	error: 'red',
+};
+
+export function formatTime(timestamp: string): string {
+	const d = new Date(timestamp);
+	const h = String(d.getHours()).padStart(2, '0');
+	const m = String(d.getMinutes()).padStart(2, '0');
+	const s = String(d.getSeconds()).padStart(2, '0');
+	const ms = String(d.getMilliseconds()).padStart(3, '0');
+	return `${h}:${m}:${s}.${ms}`;
+}


### PR DESCRIPTION
## Summary
- Created `src/lib/format.ts` with shared `LEVEL_COLORS` and `formatTime`
- Removed 4 duplicate `LEVEL_COLORS` definitions and 2 duplicate `formatTime` functions from components

Closes #33