### PR TITLE
Fix trend color semantics in stats view

### DIFF
--- a/src/components/StatsView.tsx
+++ b/src/components/StatsView.tsx
@@ -56,9 +56,9 @@ export default function StatsView({totals, period, comparison, groupBySource}: P
 		: '';
 	const trendColor = comparison
 		? comparison.trend === 'up'
-			? 'green'
+			? 'yellow'
 			: comparison.trend === 'down'
-				? 'red'
+				? 'green'
 				: 'gray'
 		: 'gray';
 


### PR DESCRIPTION
## Summary
- Changed trend up color from green to yellow (more logs = potential concern)
- Changed trend down color from red to green (fewer logs = positive)

Closes #34