### PR TITLE
Remove unused --interactive flag

### DIFF
--- a/src/lib/__tests__/output.test.ts
+++ b/src/lib/__tests__/output.test.ts
@@ -6,14 +6,6 @@ describe('isJsonMode', () => {
 		expect(isJsonMode({json: true})).toBe(true);
 	});
 
-	it('returns false when --interactive flag is set', () => {
-		expect(isJsonMode({interactive: true})).toBe(false);
-	});
-
-	it('--json takes precedence over --interactive', () => {
-		expect(isJsonMode({json: true, interactive: true})).toBe(true);
-	});
-
 	it('falls back to TTY detection', () => {
 		const originalIsTTY = process.stdout.isTTY;
 		Object.defineProperty(process.stdout, 'isTTY', {value: true, writable: true});

--- a/src/lib/output.ts
+++ b/src/lib/output.ts
@@ -1,10 +1,6 @@
-export function isJsonMode(flags: {json?: boolean; interactive?: boolean}): boolean {
+export function isJsonMode(flags: {json?: boolean}): boolean {
 	if (flags.json) {
 		return true;
-	}
-
-	if (flags.interactive) {
-		return false;
 	}
 
 	return !process.stdout.isTTY;


### PR DESCRIPTION
## Summary
- Removed unused `interactive` parameter from `isJsonMode`
- TTY detection handles this automatically
- Removed 2 related tests

Closes #36