### PR TITLE
Add confirmation prompt for config reset

### DIFF
--- a/src/commands/config/reset.tsx
+++ b/src/commands/config/reset.tsx
@@ -1,9 +1,11 @@
-import {Text} from 'ink';
-import {useEffect} from 'react';
+import {Text, Box} from 'ink';
+import {useState, useEffect} from 'react';
 import {z} from 'zod';
+import TextInput from 'ink-text-input';
 import {deleteConfig} from '../../lib/config.js';
 
 export const options = z.object({
+	force: z.boolean().default(false).describe('Skip confirmation prompt'),
 	json: z.boolean().default(false).describe('Output as JSON'),
 });
 
@@ -12,18 +14,48 @@ type Props = {
 };
 
 export default function ConfigReset({options}: Props) {
+	const [confirmed, setConfirmed] = useState(options.force);
+	const [done, setDone] = useState(false);
+	const [input, setInput] = useState('');
+
 	useEffect(() => {
+		if (!confirmed) return;
+
 		deleteConfig();
+		setDone(true);
 
 		if (options.json) {
 			console.log(JSON.stringify({reset: true}));
 			process.exit(0);
 		}
-	}, []);
+	}, [confirmed]);
 
-	if (options.json) {
+	if (options.json && !confirmed) {
+		deleteConfig();
+		console.log(JSON.stringify({reset: true}));
+		process.exit(0);
 		return null;
 	}
 
-	return <Text color="green">Config reset successfully</Text>;
+	if (done) {
+		return <Text color="green">Config reset successfully</Text>;
+	}
+
+	return (
+		<Box>
+			<Text>Are you sure you want to reset config? (y/N) </Text>
+			<TextInput
+				value={input}
+				onChange={setInput}
+				onSubmit={(value) => {
+					if (value.toLowerCase() === 'y' || value.toLowerCase() === 'yes') {
+						setConfirmed(true);
+					} else {
+						console.error('Aborted');
+						process.exit(1);
+					}
+				}}
+			/>
+		</Box>
+	);
 }


### PR DESCRIPTION
## Summary
- `timberlogs config reset` now asks for confirmation before deleting config
- Added `--force` flag to skip the prompt
- JSON mode (`--json`) bypasses the prompt for scripting compatibility

Closes #40