### PR TITLE
Remove configurable base URL and align publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,32 +1,68 @@
-name: Publish
+name: Publish to npm
 
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@v4
+
       - uses: pnpm/action-setup@v4
         with:
           version: 10
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
           registry-url: https://registry.npmjs.org
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm build
-      - run: pnpm test
-      - run: npm publish
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Run tests
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Upload dist artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true

--- a/src/commands/config/list.tsx
+++ b/src/commands/config/list.tsx
@@ -3,7 +3,6 @@ import {useEffect} from 'react';
 import {z} from 'zod';
 import {readConfig} from '../../lib/config.js';
 import {maskApiKey} from '../../lib/auth.js';
-import {DEFAULT_API_URL} from '../../types/config.js';
 
 export const options = z.object({
 	json: z.boolean().default(false).describe('Output as JSON'),
@@ -18,7 +17,6 @@ export default function ConfigList({options}: Props) {
 
 	const display = {
 		apiKey: config.apiKey ? maskApiKey(config.apiKey) : '(not set)',
-		apiUrl: config.apiUrl ?? DEFAULT_API_URL,
 	};
 
 	useEffect(() => {
@@ -37,10 +35,6 @@ export default function ConfigList({options}: Props) {
 			<Text>
 				<Text bold>API Key:  </Text>
 				<Text>{display.apiKey}</Text>
-			</Text>
-			<Text>
-				<Text bold>API URL:  </Text>
-				<Text>{display.apiUrl}</Text>
 			</Text>
 		</Box>
 	);

--- a/src/commands/config/set.tsx
+++ b/src/commands/config/set.tsx
@@ -8,7 +8,6 @@ import type {Config} from '../../types/config.js';
 
 const VALID_KEYS: Record<string, keyof Config> = {
 	'api-key': 'apiKey',
-	'api-url': 'apiUrl',
 };
 
 export const args = z.tuple([z.string().describe('key'), z.string().describe('value')]);

--- a/src/commands/flows/index.tsx
+++ b/src/commands/flows/index.tsx
@@ -1,7 +1,7 @@
 import {Text, Box} from 'ink';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
-import {requireApiKey, resolveApiUrl} from '../../lib/auth.js';
+import {requireApiKey} from '../../lib/auth.js';
 import {createApiClient} from '../../lib/api.js';
 import {parseRelativeTime} from '../../lib/time.js';
 import {handleError} from '../../lib/errors.js';
@@ -36,7 +36,6 @@ export const options = z.object({
 	offset: z.number().default(0).describe('Number of flows to skip'),
 	json: z.boolean().default(false).describe('Output as JSON'),
 	'api-key': z.string().optional().describe('Override API key'),
-	'api-url': z.string().optional().describe('Override API URL'),
 	verbose: z.boolean().default(false).describe('Show debug info'),
 });
 
@@ -73,8 +72,7 @@ export default function FlowsList({options: flags}: Props) {
 	async function fetchFlows() {
 		try {
 			const apiKey = requireApiKey({apiKey: flags['api-key']});
-			const baseUrl = resolveApiUrl({apiUrl: flags['api-url']});
-			const client = createApiClient({apiKey, baseUrl, verbose: flags.verbose});
+			const client = createApiClient({apiKey, verbose: flags.verbose});
 
 			const from = parseRelativeTime(flags.from);
 			const to = flags.to ? parseRelativeTime(flags.to) : undefined;

--- a/src/commands/flows/show.tsx
+++ b/src/commands/flows/show.tsx
@@ -1,7 +1,7 @@
 import {Text} from 'ink';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
-import {requireApiKey, resolveApiUrl} from '../../lib/auth.js';
+import {requireApiKey} from '../../lib/auth.js';
 import {createApiClient} from '../../lib/api.js';
 import {handleError} from '../../lib/errors.js';
 import {isJsonMode, jsonOutput} from '../../lib/output.js';
@@ -13,7 +13,6 @@ export const args = z.tuple([z.string().describe('flowId')]);
 export const options = z.object({
 	json: z.boolean().default(false).describe('Output as JSON'),
 	'api-key': z.string().optional().describe('Override API key'),
-	'api-url': z.string().optional().describe('Override API URL'),
 	verbose: z.boolean().default(false).describe('Show debug info'),
 });
 
@@ -42,8 +41,7 @@ export default function FlowsShow({args: [flowId], options: flags}: Props) {
 	async function fetchFlow() {
 		try {
 			const apiKey = requireApiKey({apiKey: flags['api-key']});
-			const baseUrl = resolveApiUrl({apiUrl: flags['api-url']});
-			const client = createApiClient({apiKey, baseUrl, verbose: flags.verbose});
+			const client = createApiClient({apiKey, verbose: flags.verbose});
 
 			const raw = await client.get('/v1/logs', {
 				flowId,

--- a/src/commands/index.tsx
+++ b/src/commands/index.tsx
@@ -22,14 +22,12 @@ export default function Index() {
 			<Text bold>Global Flags:</Text>
 			<Text>  --json             Force JSON output</Text>
 			<Text>  --api-key {'<key>'}    Override API key</Text>
-			<Text>  --api-url {'<url>'}    Override API endpoint</Text>
 			<Text>  --verbose          Show debug info</Text>
 			<Text>  --version, -v      Show version</Text>
 			<Text>  --help, -h         Show help</Text>
 			<Text> </Text>
 			<Text bold>Environment Variables:</Text>
 			<Text>  TIMBER_API_KEY     API key (overrides config file)</Text>
-			<Text>  TIMBER_API_URL     API endpoint (overrides config file)</Text>
 			<Text>  NO_COLOR           Disable color output</Text>
 		</Box>
 	);

--- a/src/commands/login.tsx
+++ b/src/commands/login.tsx
@@ -3,7 +3,7 @@ import TextInput from 'ink-text-input';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
 import {readConfig, writeConfig} from '../lib/config.js';
-import {maskApiKey, resolveApiUrl} from '../lib/auth.js';
+import {maskApiKey} from '../lib/auth.js';
 import {createApiClient} from '../lib/api.js';
 import {handleError} from '../lib/errors.js';
 
@@ -32,8 +32,7 @@ export default function Login({options}: Props) {
 	async function validateAndStore(key: string) {
 		setStatus('validating');
 
-		const baseUrl = resolveApiUrl({});
-		const client = createApiClient({apiKey: key, baseUrl});
+		const client = createApiClient({apiKey: key});
 
 		try {
 			await client.get('/v1/logs', {limit: 1});

--- a/src/commands/logs.tsx
+++ b/src/commands/logs.tsx
@@ -1,7 +1,7 @@
 import {Text} from 'ink';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
-import {requireApiKey, resolveApiUrl} from '../lib/auth.js';
+import {requireApiKey} from '../lib/auth.js';
 import {createApiClient} from '../lib/api.js';
 import {parseRelativeTime} from '../lib/time.js';
 import {handleError} from '../lib/errors.js';
@@ -24,7 +24,6 @@ export const options = z.object({
 	dataset: z.string().optional().describe('Filter by dataset'),
 	json: z.boolean().default(false).describe('Output as JSON'),
 	'api-key': z.string().optional().describe('Override API key'),
-	'api-url': z.string().optional().describe('Override API URL'),
 	verbose: z.boolean().default(false).describe('Show debug info'),
 });
 
@@ -44,8 +43,7 @@ export default function Logs({options: flags}: Props) {
 	async function fetchLogs() {
 		try {
 			const apiKey = requireApiKey({apiKey: flags['api-key']});
-			const baseUrl = resolveApiUrl({apiUrl: flags['api-url']});
-			const client = createApiClient({apiKey, baseUrl, verbose: flags.verbose});
+			const client = createApiClient({apiKey, verbose: flags.verbose});
 
 			const from = parseRelativeTime(flags.from);
 			const to = flags.to ? parseRelativeTime(flags.to) : undefined;

--- a/src/commands/stats.tsx
+++ b/src/commands/stats.tsx
@@ -1,7 +1,7 @@
 import {Text} from 'ink';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
-import {requireApiKey, resolveApiUrl} from '../lib/auth.js';
+import {requireApiKey} from '../lib/auth.js';
 import {createApiClient} from '../lib/api.js';
 import {parseRelativeTime} from '../lib/time.js';
 import {handleError} from '../lib/errors.js';
@@ -18,7 +18,6 @@ export const options = z.object({
 	dataset: z.string().optional().describe('Filter by dataset'),
 	json: z.boolean().default(false).describe('Output as JSON'),
 	'api-key': z.string().optional().describe('Override API key'),
-	'api-url': z.string().optional().describe('Override API URL'),
 	verbose: z.boolean().default(false).describe('Show debug info'),
 });
 
@@ -50,8 +49,7 @@ export default function Stats({options: flags}: Props) {
 	async function fetchStats() {
 		try {
 			const apiKey = requireApiKey({apiKey: flags['api-key']});
-			const baseUrl = resolveApiUrl({apiUrl: flags['api-url']});
-			const client = createApiClient({apiKey, baseUrl, verbose: flags.verbose});
+			const client = createApiClient({apiKey, verbose: flags.verbose});
 
 			const fromMs = parseRelativeTime(flags.from);
 			const toMs = flags.to ? parseRelativeTime(flags.to) : Date.now();

--- a/src/commands/whoami.tsx
+++ b/src/commands/whoami.tsx
@@ -1,7 +1,7 @@
 import {Text, Box} from 'ink';
 import {useState, useEffect} from 'react';
 import {z} from 'zod';
-import {resolveApiKey, maskApiKey, resolveApiUrl} from '../lib/auth.js';
+import {resolveApiKey, maskApiKey} from '../lib/auth.js';
 import {createApiClient} from '../lib/api.js';
 import {handleError, CliError, ErrorCode} from '../lib/errors.js';
 
@@ -17,7 +17,6 @@ type Props = {
 type Result = {
 	authenticated: boolean;
 	keyPrefix?: string;
-	apiUrl?: string;
 	error?: string;
 };
 
@@ -39,8 +38,7 @@ export default function WhoAmI({options}: Props) {
 			return;
 		}
 
-		const apiUrl = resolveApiUrl({});
-		const client = createApiClient({apiKey: key, baseUrl: apiUrl});
+		const client = createApiClient({apiKey: key});
 
 		try {
 			await client.get('/v1/logs', {limit: 1});
@@ -59,7 +57,6 @@ export default function WhoAmI({options}: Props) {
 		const info = {
 			authenticated: true,
 			keyPrefix: maskApiKey(key),
-			apiUrl,
 		};
 
 		if (options.json) {
@@ -91,10 +88,6 @@ export default function WhoAmI({options}: Props) {
 			<Text>
 				<Text bold>{'API Key:      '}</Text>
 				<Text>{result.keyPrefix}</Text>
-			</Text>
-			<Text>
-				<Text bold>{'API Endpoint: '}</Text>
-				<Text>{result.apiUrl}</Text>
 			</Text>
 		</Box>
 	);

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,5 +1,5 @@
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {resolveApiKey, requireApiKey, maskApiKey, resolveApiUrl} from '../auth.js';
+import {resolveApiKey, requireApiKey, maskApiKey} from '../auth.js';
 import {CliError} from '../errors.js';
 
 vi.mock('../config.js', () => ({
@@ -60,40 +60,6 @@ describe('requireApiKey', () => {
 	it('throws CliError when no key', () => {
 		expect(() => requireApiKey({})).toThrow(CliError);
 		expect(() => requireApiKey({})).toThrow('No API key found');
-	});
-});
-
-describe('resolveApiUrl', () => {
-	const originalEnv = process.env;
-
-	beforeEach(() => {
-		process.env = {...originalEnv};
-		delete process.env['TIMBER_API_URL'];
-		mockedReadConfig.mockReturnValue({});
-	});
-
-	afterEach(() => {
-		process.env = originalEnv;
-	});
-
-	it('returns flag value first', () => {
-		process.env['TIMBER_API_URL'] = 'https://env.example.com';
-		mockedReadConfig.mockReturnValue({apiUrl: 'https://config.example.com'});
-		expect(resolveApiUrl({apiUrl: 'https://flag.example.com'})).toBe('https://flag.example.com');
-	});
-
-	it('falls back to env var', () => {
-		process.env['TIMBER_API_URL'] = 'https://env.example.com';
-		expect(resolveApiUrl({})).toBe('https://env.example.com');
-	});
-
-	it('falls back to config file', () => {
-		mockedReadConfig.mockReturnValue({apiUrl: 'https://config.example.com'});
-		expect(resolveApiUrl({})).toBe('https://config.example.com');
-	});
-
-	it('returns default URL when nothing set', () => {
-		expect(resolveApiUrl({})).toBe('https://timberlogs-ingest.enaboapps.workers.dev');
 	});
 });
 

--- a/src/lib/__tests__/config.test.ts
+++ b/src/lib/__tests__/config.test.ts
@@ -42,8 +42,8 @@ describe('config', () => {
 		});
 
 		it('reads existing config', () => {
-			writeConfig({apiKey: 'test-key', apiUrl: 'https://example.com'});
-			expect(readConfig()).toEqual({apiKey: 'test-key', apiUrl: 'https://example.com'});
+			writeConfig({apiKey: 'test-key'});
+			expect(readConfig()).toEqual({apiKey: 'test-key'});
 		});
 	});
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,5 @@
 import {CliError, ErrorCode} from './errors.js';
+import {API_URL} from '../types/config.js';
 
 export interface ApiClient {
 	get<T>(path: string, params?: Record<string, string | number | undefined>): Promise<T>;
@@ -7,10 +8,10 @@ export interface ApiClient {
 
 export function createApiClient(options: {
 	apiKey: string;
-	baseUrl: string;
 	verbose?: boolean;
 }): ApiClient {
-	const {apiKey, baseUrl, verbose} = options;
+	const {apiKey, verbose} = options;
+	const baseUrl = API_URL;
 
 	const headers: Record<string, string> = {
 		Authorization: `Bearer ${apiKey}`,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,5 @@
 import {readConfig} from './config.js';
 import {CliError, ErrorCode} from './errors.js';
-import {DEFAULT_API_URL} from '../types/config.js';
 
 export function resolveApiKey(flags: {apiKey?: string}): string | null {
 	if (flags.apiKey) {
@@ -32,24 +31,6 @@ export function requireApiKey(flags: {apiKey?: string}): string {
 	return key;
 }
 
-export function resolveApiUrl(flags: {apiUrl?: string}): string {
-	let url: string;
-
-	if (flags.apiUrl) {
-		url = flags.apiUrl;
-	} else if (process.env['TIMBER_API_URL']) {
-		url = process.env['TIMBER_API_URL'];
-	} else {
-		const config = readConfig();
-		url = config.apiUrl ?? DEFAULT_API_URL;
-	}
-
-	if (url.startsWith('http://') && !url.includes('localhost') && !url.includes('127.0.0.1')) {
-		console.error('⚠ Warning: API URL uses HTTP. Consider using HTTPS for secure communication.');
-	}
-
-	return url;
-}
 
 export function maskApiKey(key: string): string {
 	if (key.length < 16) {

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,6 +1,5 @@
 export interface Config {
 	apiKey?: string;
-	apiUrl?: string;
 }
 
-export const DEFAULT_API_URL = 'https://timberlogs-ingest.enaboapps.workers.dev';
+export const API_URL = 'https://timberlogs-ingest.enaboapps.workers.dev';


### PR DESCRIPTION
## Summary
- **Base URL no longer configurable**: Removed `--api-url` flag, `TIMBER_API_URL` env var, and `apiUrl` config option. API URL is now hardcoded via `API_URL` constant in `types/config.ts`
- **Publish workflow aligned with TS SDK**: Triggers on `release: [published]`, separate build/publish jobs, `npm publish --provenance --access public`, lint step added

## Files changed (15)
- Removed `resolveApiUrl` from `lib/auth.ts`
- `API_URL` hardcoded in `lib/api.ts` via import from `types/config.ts`
- Removed `--api-url` from all 5 command option schemas
- Removed `apiUrl` from Config type and config set/list commands
- Removed from help text and env var docs
- Updated auth and config tests
- Rewrote `.github/workflows/publish.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Removed Features**
  * Removed the `--api-url` CLI flag and configuration option for overriding the API endpoint; the application now uses a single fixed API URL.

* **Improvements**
  * Strengthened release process with automated build verification, linting, and testing before publishing.
  * Added cryptographic provenance signatures to npm packages for enhanced security and verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->