### PR TITLE
Fix audit round 2: offset bug, pagination, config reset, docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ Interactive mode: use arrow keys to navigate, Enter to expand a log, `q` to quit
 ### Flows
 
 ```bash
+timberlogs flows                        # List all flows
+timberlogs flows --from 7d              # Flows from last 7 days
 timberlogs flows show <flow-id>         # View flow timeline
 timberlogs flows show checkout-abc      # Example
 ```
@@ -75,7 +77,6 @@ timberlogs stats --group-by source      # Group by source
 
 ```bash
 timberlogs config set api-key <key>     # Set API key
-timberlogs config set api-url <url>     # Set API endpoint
 timberlogs config list                   # Show current config
 timberlogs config reset                  # Delete config file
 ```
@@ -86,7 +87,6 @@ timberlogs config reset                  # Delete config file
 |------|-------------|
 | `--json` | Force JSON output |
 | `--api-key <key>` | Override API key for this command |
-| `--api-url <url>` | Override API endpoint |
 | `--verbose` | Show HTTP request details |
 | `--version`, `-v` | Show version |
 | `--help`, `-h` | Show help |
@@ -111,7 +111,6 @@ timberlogs logs --search "500 error" --json --from 1h
 | Variable | Description |
 |----------|-------------|
 | `TIMBER_API_KEY` | API key (overrides config file) |
-| `TIMBER_API_URL` | API endpoint (overrides config file) |
 | `NO_COLOR` | Disable color output |
 | `TIMBERLOGS_CONFIG_DIR` | Custom config directory (default: `~/.config/timberlogs`) |
 

--- a/src/commands/config/reset.tsx
+++ b/src/commands/config/reset.tsx
@@ -31,9 +31,8 @@ export default function ConfigReset({options}: Props) {
 	}, [confirmed]);
 
 	if (options.json && !confirmed) {
-		deleteConfig();
-		console.log(JSON.stringify({reset: true}));
-		process.exit(0);
+		console.error(JSON.stringify({error: true, message: 'Use --force to skip confirmation'}));
+		process.exit(1);
 		return null;
 	}
 

--- a/src/commands/flows/index.tsx
+++ b/src/commands/flows/index.tsx
@@ -82,7 +82,7 @@ export default function FlowsList({options: flags}: Props) {
 				to,
 				source: flags.source,
 				limit: flags.limit,
-				offset: flags.offset || undefined,
+				offset: flags.offset > 0 ? flags.offset : undefined,
 			});
 			const response = FlowsResponseSchema.parse(raw);
 

--- a/src/commands/logs.tsx
+++ b/src/commands/logs.tsx
@@ -55,7 +55,7 @@ export default function Logs({options: flags}: Props) {
 				from,
 				to,
 				limit: flags.limit,
-				offset: flags.offset || undefined,
+				offset: flags.offset > 0 ? flags.offset : undefined,
 				userId: flags['user-id'],
 				sessionId: flags['session-id'],
 				flowId: flags['flow-id'],

--- a/src/components/LogTable.tsx
+++ b/src/components/LogTable.tsx
@@ -85,7 +85,7 @@ export default function LogTable({logs, pagination, filterSummary}: Props) {
 			})}
 
 			<Text dimColor>
-				{pagination.offset + logs.length}/{pagination.total} logs
+				{pagination.total != null ? `${pagination.offset + logs.length}/${pagination.total} logs` : `${logs.length} logs`}
 				{pagination.hasMore ? '' : ' (end)'}
 				{'  ↑↓ navigate  Enter expand  q quit'}
 			</Text>


### PR DESCRIPTION
## Summary
- **Offset bug**: `flags.offset || undefined` treated `0` as falsy, sending `undefined` instead of omitting cleanly. Fixed in both `logs.tsx` and `flows/index.tsx`
- **Pagination display**: `LogTable` rendered `50/undefined logs` when `pagination.total` was absent. Now shows `50 logs` gracefully
- **Config reset double deletion**: JSON mode without `--force` called `deleteConfig()` immediately bypassing confirmation. Now requires `--force` in JSON mode
- **Stale README**: Removed `--api-url`, `TIMBER_API_URL`, `config set api-url` references that were removed in PR #56. Added `flows` list command docs

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm lint` passes
- [x] Tested `timberlogs logs`, `timberlogs flows`, `timberlogs config list` against live API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `timberlogs flows` command to list all flows with optional date range filtering (e.g., `--from 7d`)

* **Bug Fixes**
  * Fixed config reset to properly return JSON error when operation not confirmed
  * Improved pagination display to gracefully handle unknown total log counts

* **Chores**
  * Removed API URL configuration pathway and associated documentation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->