### PR TITLE
ci: add environment to publish job for OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -55,6 +55,7 @@ jobs:
   publish:
     needs: release
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Adds \ to the publish job — npm's trusted publishing requires the OIDC token to be scoped to a named environment that matches the configuration on npmjs.com.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to enhance the publish process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->