### PR TITLE
ci: revert publish trigger to release published

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,8 @@
 name: Publish to npm
 
 on:
-  push:
-    tags:
-      - 'v*.*.*'
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -39,23 +38,9 @@ jobs:
           name: dist
           path: dist/
 
-  release:
+  publish:
     needs: build
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          generate_release_notes: true
-
-  publish:
-    needs: release
-    runs-on: ubuntu-latest
-    environment: npm
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Matches the TypeScript SDK workflow — triggers on GitHub Release published instead of tag push. Removes the auto-release job and environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined the publishing workflow to trigger on GitHub Release publication instead of tag-based events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->