### PR TITLE
feat: rename organizations → workspaces in CLI

### DIFF
--- a/src/commands/login.tsx
+++ b/src/commands/login.tsx
@@ -23,7 +23,7 @@ type DeviceResponse = {
 
 type TokenResponse = {
 	access_token: string;
-	organization_name?: string;
+	workspace_name?: string;
 };
 
 type TokenErrorResponse = {
@@ -47,7 +47,7 @@ export default function Login({options}: Props) {
 	const [status, setStatus] = useState<'init' | 'polling' | 'success' | 'error'>('init');
 	const [errorMsg, setErrorMsg] = useState('');
 	const [userCode, setUserCode] = useState('');
-	const [orgName, setOrgName] = useState<string | undefined>();
+	const [workspaceName, setWorkspaceName] = useState<string | undefined>();
 
 	useEffect(() => {
 		void startDeviceFlow();
@@ -111,12 +111,12 @@ export default function Login({options}: Props) {
 				config.sessionToken = token.access_token;
 				writeConfig(config);
 
-				setOrgName(token.organization_name);
+				setWorkspaceName(token.workspace_name);
 
 				if (options.json) {
 					console.log(JSON.stringify({
 						authenticated: true,
-						...(token.organization_name ? {organization: token.organization_name} : {}),
+						...(token.workspace_name ? {workspace: token.workspace_name} : {}),
 					}));
 					process.exit(0);
 				}
@@ -180,7 +180,7 @@ export default function Login({options}: Props) {
 		return (
 			<Box flexDirection="column">
 				<Text color="green">✓ Authenticated successfully</Text>
-				{orgName && <Text color="green">✓ Organization: {orgName}</Text>}
+				{workspaceName && <Text color="green">✓ Workspace: {workspaceName}</Text>}
 			</Box>
 		);
 	}

--- a/src/commands/whoami.tsx
+++ b/src/commands/whoami.tsx
@@ -15,7 +15,7 @@ type Props = {
 
 type Result = {
 	authenticated: boolean;
-	organization?: string;
+	workspace?: string;
 	error?: string;
 };
 
@@ -39,10 +39,10 @@ export default function WhoAmI({options}: Props) {
 
 		const client = createApiClient({token});
 
-		let orgName: string | undefined;
+		let workspaceName: string | undefined;
 		try {
-			const whoami = await client.get<{organizationName?: string}>('/v1/whoami');
-			orgName = whoami.organizationName;
+			const whoami = await client.get<{workspaceName?: string}>('/v1/whoami');
+			workspaceName = whoami.workspaceName;
 		} catch (error) {
 			if (options.json) {
 				handleError(error, true);
@@ -57,7 +57,7 @@ export default function WhoAmI({options}: Props) {
 
 		const info: Result = {
 			authenticated: true,
-			...(orgName ? {organization: orgName} : {}),
+			...(workspaceName ? {workspace: workspaceName} : {}),
 		};
 
 		if (options.json) {
@@ -86,10 +86,10 @@ export default function WhoAmI({options}: Props) {
 				<Text bold>{'Status:       '}</Text>
 				<Text color="green">Authenticated</Text>
 			</Text>
-			{result.organization && (
+			{result.workspace && (
 				<Text>
-					<Text bold>{'Organization: '}</Text>
-					<Text>{result.organization}</Text>
+					<Text bold>{'Workspace:    '}</Text>
+					<Text>{result.workspace}</Text>
 				</Text>
 			)}
 		</Box>

--- a/src/components/ReplView.tsx
+++ b/src/components/ReplView.tsx
@@ -23,7 +23,7 @@ import type {ReplEntry} from './ReplOutput.js';
 
 const COMMANDS_HINT = 'logs  stats  flows  flows show  whoami  login  logout  config list  help  exit';
 
-function ReplHeader({token, orgName}: {token: string | null; orgName: string | null}) {
+function ReplHeader({token, workspaceName}: {token: string | null; workspaceName: string | null}) {
 	const cols = process.stdout.columns || 80;
 	return (
 		<Box flexDirection="column">
@@ -34,7 +34,7 @@ function ReplHeader({token, orgName}: {token: string | null; orgName: string | n
 					<Text dimColor>v{CLI_VERSION}</Text>
 				</Box>
 				{token ? (
-					<Text><Text color="green">● </Text><Text>{orgName ?? 'Authenticated'}</Text></Text>
+					<Text><Text color="green">● </Text><Text>{workspaceName ?? 'Authenticated'}</Text></Text>
 				) : (
 					<Text><Text color="red">● </Text><Text dimColor>Not logged in</Text></Text>
 				)}
@@ -73,13 +73,13 @@ export default function ReplView() {
 	const [phase, setPhase] = useState<Phase>({tag: 'idle'});
 	const [history, setHistory] = useState<string[]>([]);
 	const [token, setToken] = useState<string | null>(null);
-	const [orgName, setOrgName] = useState<string | null>(null);
+	const [workspaceName, setWorkspaceName] = useState<string | null>(null);
 
-	const fetchOrgName = useCallback(async (t: string) => {
+	const fetchWorkspaceName = useCallback(async (t: string) => {
 		try {
 			const client = createApiClient({token: t});
-			const whoami = await client.get<{organizationName?: string}>('/v1/whoami');
-			if (whoami.organizationName) setOrgName(whoami.organizationName);
+			const whoami = await client.get<{workspaceName?: string}>('/v1/whoami');
+			if (whoami.workspaceName) setWorkspaceName(whoami.workspaceName);
 		} catch {
 			// silently fail — header shows "Authenticated" fallback
 		}
@@ -91,8 +91,8 @@ export default function ReplView() {
 	}, []);
 
 	useEffect(() => {
-		if (!token) { setOrgName(null); return; }
-		void fetchOrgName(token);
+		if (!token) { setWorkspaceName(null); return; }
+		void fetchWorkspaceName(token);
 	}, [token]);
 
 	function addEntry(entry: ReplEntry) {
@@ -276,7 +276,7 @@ export default function ReplView() {
 
 	return (
 		<Box flexDirection="column">
-			<ReplHeader token={token} orgName={orgName} />
+			<ReplHeader token={token} workspaceName={workspaceName} />
 			{visibleEntries.map((entry, i) => (
 				<ReplOutput key={i} entry={entry} />
 			))}

--- a/src/components/commandViews/LoginView.tsx
+++ b/src/components/commandViews/LoginView.tsx
@@ -14,7 +14,7 @@ type DeviceResponse = {
 
 type TokenResponse = {
 	access_token: string;
-	organization_name?: string;
+	workspace_name?: string;
 };
 
 type TokenErrorResponse = {
@@ -99,8 +99,8 @@ export default function LoginView({onDone, onError}: Props) {
 				onDone(
 					<Box flexDirection="column">
 						<Text color="green">✓ Authenticated successfully</Text>
-						{token.organization_name ? (
-							<Text color="green">✓ Organization: {token.organization_name}</Text>
+						{token.workspace_name ? (
+							<Text color="green">✓ Workspace: {token.workspace_name}</Text>
 						) : null}
 					</Box>,
 					false,

--- a/src/components/commandViews/WhoamiView.tsx
+++ b/src/components/commandViews/WhoamiView.tsx
@@ -17,12 +17,12 @@ export default function WhoamiView({token, onDone, onError}: Props) {
 	async function run() {
 		try {
 			const client = createApiClient({token});
-			const whoami = await client.get<{organizationName?: string}>('/v1/whoami');
+			const whoami = await client.get<{workspaceName?: string}>('/v1/whoami');
 			onDone(
 				<Box flexDirection="column">
 					<Text><Text bold>{'Status:       '}</Text><Text color="green">Authenticated</Text></Text>
-					{whoami.organizationName ? (
-						<Text><Text bold>{'Organization: '}</Text><Text>{whoami.organizationName}</Text></Text>
+					{whoami.workspaceName ? (
+						<Text><Text bold>{'Workspace:    '}</Text><Text>{whoami.workspaceName}</Text></Text>
 					) : null}
 				</Box>,
 				false,


### PR DESCRIPTION
## Summary

- Renames all `organization`/`orgName`/`organizationName` references to `workspace`/`workspaceName` across auth and whoami flows
- Updates UI labels from `Organization:` → `Workspace:`
- Updates API response type expectation on `/v1/whoami` (`organizationName` → `workspaceName`)
- Updates token response type (`organization_name` → `workspace_name`)

Closes #84. Part of [timberlogs-core#863](https://github.com/enaboapps/timberlogs-core/issues/863).

## Files changed
- `src/commands/whoami.tsx`
- `src/commands/login.tsx`
- `src/components/ReplView.tsx`
- `src/components/commandViews/LoginView.tsx`
- `src/components/commandViews/WhoamiView.tsx`

## Test plan
- [ ] `timberlogs login` — success message shows `✓ Workspace: <name>` 
- [ ] `timberlogs whoami` — output shows `Workspace:` label
- [ ] REPL header shows workspace name when authenticated
- [ ] `--json` flag on `whoami` outputs `workspace` key (not `organization`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Authentication and profile features now use "Workspace" terminology instead of "Organization" throughout the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->