### PR TITLE
Fix npm publishing workflow for v1.1.2

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -16,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -43,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -63,4 +65,4 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --access public


### PR DESCRIPTION
Closes #91.

## Summary
- Use Node 24 in the npm publish workflow so npm trusted publishing runs on a supported Node/npm baseline.
- Add workflow_dispatch so the v1.1.2 package can be published after the release event already fired.
- Remove the explicit --provenance flag and let npm trusted publishing generate provenance automatically.
- Add contents: read beside id-token: write for the publish job permissions.

## Test plan
- Workflow-only change; CI on this PR validates the repository build/lint/test path.
- After merge to main, manually dispatch Publish to npm from main and verify npm view timberlogs-cli version returns 1.1.2.