### PR TITLE
Release v1.1.2 publish workflow fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,7 @@ name: Publish to npm
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   build:
@@ -16,7 +17,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -43,6 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -52,7 +54,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -63,4 +65,4 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --access public


### PR DESCRIPTION
## Summary
- Bring the npm publish workflow fix from dev to main for the v1.1.2 publish retry.
- Uses Node 24, adds workflow_dispatch, and relies on npm trusted publishing automatic provenance.

## Test plan
- PR #92 CI passed on dev.
- After this merges, manually dispatch Publish to npm from main and verify npm view timberlogs-cli version returns 1.1.2.