### PR TITLE
Update npm package metadata for org move

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/enaboapps/timberlogs-cli.git"
+    "url": "git+https://github.com/timberlogs/timberlogs-cli.git"
   },
   "homepage": "https://timberlogs.dev",
   "bugs": {
-    "url": "https://github.com/enaboapps/timberlogs-cli/issues"
+    "url": "https://github.com/timberlogs/timberlogs-cli/issues"
   },
   "type": "module",
   "bin": {
-    "timberlogs": "./dist/cli.js"
+    "timberlogs": "dist/cli.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Refs #91.

## Summary
- Update package repository and bugs URLs from enaboapps/timberlogs-cli to timberlogs/timberlogs-cli.
- Keep npm-normalized repository and bin metadata so publish no longer auto-corrects those fields.
- Align package metadata with the repository identity used by GitHub Actions trusted publishing.

## Test plan
- npm pack --dry-run: passed and produced timberlogs-cli-1.1.2.tgz metadata without package metadata correction warnings.
- CI on this PR validates lint/build/test.