### PR TITLE
Release v1.1.2 metadata fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,15 +13,15 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/enaboapps/timberlogs-cli.git"
+    "url": "git+https://github.com/timberlogs/timberlogs-cli.git"
   },
   "homepage": "https://timberlogs.dev",
   "bugs": {
-    "url": "https://github.com/enaboapps/timberlogs-cli/issues"
+    "url": "https://github.com/timberlogs/timberlogs-cli/issues"
   },
   "type": "module",
   "bin": {
-    "timberlogs": "./dist/cli.js"
+    "timberlogs": "dist/cli.js"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary
- Bring package metadata updates from dev to main for the v1.1.2 publish retry.
- Align package repository URLs with timberlogs/timberlogs-cli and keep npm metadata normalized.

## Test plan
- PR #94 CI passed on dev.
- npm pack --dry-run passed locally without package metadata correction warnings.
- After merge, manually dispatch Publish to npm from main and verify npm view timberlogs-cli version returns 1.1.2.