### PR TITLE
Grant publish workflow OIDC permission globally

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Refs #91.

## Summary
- Add workflow-level id-token: write and contents: read permissions to the npm publish workflow.
- Keep the publish job permissions in place, but ensure release-triggered runs receive OIDC permission for npm trusted publishing.

## Test plan
- CI on this PR validates lint/build/test.
- After merge to main, move v1.1.2 to current main again and recreate the release to retry npm publish.