### PR TITLE
Release v1.1.2 OIDC permission fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,10 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Bring the workflow-level OIDC permission fix from dev to main for the v1.1.2 npm publish retry.

## Test plan
- PR #97 CI passed on dev.
- After merge, move v1.1.2 to current main and recreate the release to retry npm publishing.