### PR TITLE
Use OIDC auth for npm publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,4 +69,7 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          npm config delete //registry.npmjs.org/:_authToken || true
+          unset NODE_AUTH_TOKEN
+          npm publish --access public


### PR DESCRIPTION
Refs #91.

## Summary
- Clear setup-node's registry token config before npm publish.
- Unset NODE_AUTH_TOKEN so npm can use trusted publishing OIDC from GitHub Actions.
- Keep the package publish command as npm publish --access public.

## Test plan
- CI on this PR validates lint/build/test.
- After merge to main, move v1.1.2 to current main and recreate the release to retry npm publishing.