### PR TITLE
Release v1.1.2 OIDC auth fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -69,4 +69,7 @@ jobs:
         run: pnpm build
 
       - name: Publish to npm
-        run: npm publish --access public
+        run: |
+          npm config delete //registry.npmjs.org/:_authToken || true
+          unset NODE_AUTH_TOKEN
+          npm publish --access public


### PR DESCRIPTION
## Summary
- Bring the npm publish OIDC auth fix from dev to main.
- Clears setup-node token auth before npm publish so npm can use trusted publishing OIDC.

## Test plan
- PR #99 CI passed on dev.
- After merge, move v1.1.2 to current main and recreate the release to retry npm publishing.