### PR TITLE
Export npm OIDC token explicitly

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,4 +72,6 @@ jobs:
         run: |
           npm config delete //registry.npmjs.org/:_authToken || true
           unset NODE_AUTH_TOKEN
+          OIDC_RESPONSE="$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm%3Aregistry.npmjs.org")"
+          export NPM_ID_TOKEN="$(node -e "process.stdout.write(JSON.parse(process.argv[1]).value)" "$OIDC_RESPONSE")"
           npm publish --access public


### PR DESCRIPTION
Refs #91.

## Summary
- Request a GitHub OIDC token with audience npm:registry.npmjs.org during the publish step.
- Export it as NPM_ID_TOKEN so npm trusted publishing can authenticate without a long-lived token.
- Keep setup-node token auth cleared before publish.

## Test plan
- CI on this PR validates lint/build/test.
- After merge to main, move v1.1.2 to current main and recreate the release to retry npm publishing.