### PR TITLE
Release v1.1.2 explicit OIDC token fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,4 +72,6 @@ jobs:
         run: |
           npm config delete //registry.npmjs.org/:_authToken || true
           unset NODE_AUTH_TOKEN
+          OIDC_RESPONSE="$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=npm%3Aregistry.npmjs.org")"
+          export NPM_ID_TOKEN="$(node -e "process.stdout.write(JSON.parse(process.argv[1]).value)" "$OIDC_RESPONSE")"
           npm publish --access public


### PR DESCRIPTION
## Summary
- Bring explicit npm OIDC token export from dev to main for the v1.1.2 publish retry.

## Test plan
- PR #101 CI passed on dev.
- After merge, move v1.1.2 to current main and recreate the release to retry npm publishing.