### PR TITLE
Add npm environment to publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
Refs #91.

## Summary
- Set the publish job environment to npm.
- Align the GitHub OIDC subject with npm trusted publisher configurations that include the npm environment name.
- Keep explicit OIDC token export in the publish step.

## Test plan
- CI on this PR validates lint/build/test.
- After merge to main, move v1.1.2 to current main and recreate the release to retry npm publishing.