### PR TITLE
Release v1.1.2 npm environment fix

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,6 +46,7 @@ jobs:
   publish:
     needs: build
     runs-on: ubuntu-latest
+    environment: npm
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
## Summary
- Bring the npm publish environment fix from dev to main.
- Sets the publish job environment to npm so trusted publishing can match an environment-scoped publisher.

## Test plan
- PR #103 CI passed on dev.
- After merge, move v1.1.2 to current main and recreate the release to retry npm publishing.